### PR TITLE
migrate current stable version of bloc DevTools

### DIFF
--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -14,6 +14,7 @@ import 'analytics/constants.dart' as analytics_constants;
 import 'analytics/provider.dart';
 import 'app_size/app_size_controller.dart';
 import 'app_size/app_size_screen.dart';
+import 'bloc/views/bloc_screen.dart';
 import 'common_widgets.dart';
 import 'config_specific/server/server.dart';
 import 'debugger/debugger_controller.dart';
@@ -641,6 +642,7 @@ List<DevToolsScreen> get defaultScreens {
       createController: () => LoggingController(),
     ),
     DevToolsScreen<void>(const ProviderScreen(), createController: () {}),
+    DevToolsScreen<void>(const BlocScreen(), createController: () {}),
     DevToolsScreen<AppSizeController>(
       const AppSizeScreen(),
       createController: () => AppSizeController(),

--- a/packages/devtools_app/lib/src/bloc/bloc/bloc_list_bloc.dart
+++ b/packages/devtools_app/lib/src/bloc/bloc/bloc_list_bloc.dart
@@ -44,7 +44,6 @@ class BlocListBloc extends Bloc<BlocListEvent, BlocListState> {
       BlocListRequested event) async* {
     try {
       final List<BlocNode> blocList = await _getBlocList();
-      // yield state.copyWith(blocs: blocList, status: BlocListStatus.success);
       yield BlocListState(blocs: blocList, status: BlocListStatus.success);
     } catch (e) {
       print(e);

--- a/packages/devtools_app/lib/src/bloc/bloc/bloc_list_bloc.dart
+++ b/packages/devtools_app/lib/src/bloc/bloc/bloc_list_bloc.dart
@@ -14,9 +14,7 @@ class BlocListBloc extends Bloc<BlocListEvent, BlocListState> {
       : super(const BlocListState()) {
     subscription = service.onExtensionEvent.where((event) {
       return event.extensionKind == 'bloc:bloc_map_changed';
-    }).listen((_) {
-      add(BlocListRequested());
-    });
+    }).listen((_) => add(BlocListRequested()));
   }
 
   final isAlive = Disposable();
@@ -41,7 +39,8 @@ class BlocListBloc extends Bloc<BlocListEvent, BlocListState> {
   }
 
   Stream<BlocListState> _mapBlocListRequestedToState(
-      BlocListRequested event,) async* {
+    BlocListRequested event,
+  ) async* {
     try {
       final List<BlocNode> blocList = await _getBlocList();
       yield BlocListState(blocs: blocList, status: BlocListStatus.success);
@@ -56,8 +55,8 @@ class BlocListBloc extends Bloc<BlocListEvent, BlocListState> {
         isAlive: isAlive);
     final blocMap = await evalOnDartLibrary.getInstance(blocMapRef, isAlive);
     return blocMap.associations
-      .where((a) => a.key is! Sentinel && a.value is! Sentinel)
-      .map((a) => BlocNode(a.key.valueAsString, a.value.classRef.name))
-      .toList();
+        .where((a) => a.key is! Sentinel && a.value is! Sentinel)
+        .map((a) => BlocNode(a.key.valueAsString, a.value.classRef.name))
+        .toList();
   }
 }

--- a/packages/devtools_app/lib/src/bloc/bloc/bloc_list_bloc.dart
+++ b/packages/devtools_app/lib/src/bloc/bloc/bloc_list_bloc.dart
@@ -45,8 +45,7 @@ class BlocListBloc extends Bloc<BlocListEvent, BlocListState> {
     try {
       final List<BlocNode> blocList = await _getBlocList();
       yield BlocListState(blocs: blocList, status: BlocListStatus.success);
-    } catch (e) {
-      print(e);
+    } catch (_) {
       yield state.copyWith(status: BlocListStatus.failure);
     }
   }

--- a/packages/devtools_app/lib/src/bloc/bloc/bloc_list_bloc.dart
+++ b/packages/devtools_app/lib/src/bloc/bloc/bloc_list_bloc.dart
@@ -41,7 +41,7 @@ class BlocListBloc extends Bloc<BlocListEvent, BlocListState> {
   }
 
   Stream<BlocListState> _mapBlocListRequestedToState(
-      BlocListRequested event) async* {
+      BlocListRequested event,) async* {
     try {
       final List<BlocNode> blocList = await _getBlocList();
       yield BlocListState(blocs: blocList, status: BlocListStatus.success);

--- a/packages/devtools_app/lib/src/bloc/bloc/bloc_list_bloc.dart
+++ b/packages/devtools_app/lib/src/bloc/bloc/bloc_list_bloc.dart
@@ -17,7 +17,6 @@ class BlocListBloc extends Bloc<BlocListEvent, BlocListState> {
     }).listen((_) {
       add(BlocListRequested());
     });
-    add(BlocListRequested());
   }
 
   final isAlive = Disposable();
@@ -28,6 +27,7 @@ class BlocListBloc extends Bloc<BlocListEvent, BlocListState> {
   @override
   Future<void> close() {
     subscription.cancel();
+    isAlive.dispose();
     return super.close();
   }
 

--- a/packages/devtools_app/lib/src/bloc/bloc/bloc_list_bloc.dart
+++ b/packages/devtools_app/lib/src/bloc/bloc/bloc_list_bloc.dart
@@ -55,7 +55,7 @@ class BlocListBloc extends Bloc<BlocListEvent, BlocListState> {
     final blocMapRef = await evalOnDartLibrary.safeEval('Bloc.observer.blocMap',
         isAlive: isAlive);
     final blocMap = await evalOnDartLibrary.getInstance(blocMapRef, isAlive);
-    return blocMap.associates
+    return blocMap.associations
       .where((a) => a.key is! Sentinel && a.value is! Sentinel)
       .map((a) => BlocNode(a.key.valueAsString, a.value.classRef.name))
       .toList();

--- a/packages/devtools_app/lib/src/bloc/bloc/bloc_list_bloc.dart
+++ b/packages/devtools_app/lib/src/bloc/bloc/bloc_list_bloc.dart
@@ -1,0 +1,73 @@
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
+import 'package:vm_service/vm_service.dart';
+
+import '../../eval_on_dart_library.dart';
+import '../models/bloc_node.dart';
+
+import 'bloc_list_event.dart';
+import 'bloc_list_state.dart';
+
+class BlocListBloc extends Bloc<BlocListEvent, BlocListState> {
+  BlocListBloc(this.evalOnDartLibrary, this.service)
+      : super(const BlocListState()) {
+    subscription = service.onExtensionEvent.where((event) {
+      return event.extensionKind == 'bloc:bloc_map_changed';
+    }).listen((_) {
+      add(BlocListRequested());
+    });
+    add(BlocListRequested());
+  }
+
+  final isAlive = Disposable();
+  final EvalOnDartLibrary evalOnDartLibrary;
+  final VmService service;
+  StreamSubscription<void> subscription;
+
+  @override
+  Future<void> close() {
+    subscription.cancel();
+    return super.close();
+  }
+
+  @override
+  Stream<BlocListState> mapEventToState(
+    BlocListEvent event,
+  ) async* {
+    if (event is BlocListRequested) {
+      yield* _mapBlocListRequestedToState(event);
+    }
+  }
+
+  Stream<BlocListState> _mapBlocListRequestedToState(
+      BlocListRequested event) async* {
+    try {
+      final List<BlocNode> blocList = await _getBlocList();
+      // yield state.copyWith(blocs: blocList, status: BlocListStatus.success);
+      yield BlocListState(blocs: blocList, status: BlocListStatus.success);
+    } catch (e) {
+      print(e);
+      yield state.copyWith(status: BlocListStatus.failure);
+    }
+  }
+
+  // Creates and populates a List<BlocNode> which holds BlocNodes that serve as references to the active blocs in the attached application.
+  Future<List<BlocNode>> _getBlocList() async {
+    final blocMapRef = await evalOnDartLibrary.safeEval('Bloc.observer.blocMap',
+        isAlive: isAlive);
+    final blocMap = await evalOnDartLibrary.getInstance(blocMapRef, isAlive);
+    final List<BlocNode> blocs = [];
+    for (var element in blocMap.associations) {
+      final keyResult = element.key;
+      final valueResult = element.value;
+      if (keyResult is! Sentinel && valueResult is! Sentinel) {
+        final elementId = element.key.valueAsString;
+        final elementType = element.value.classRef.name;
+        final BlocNode next = BlocNode(elementId, elementType);
+        blocs.add(next);
+      }
+    }
+    return blocs;
+  }
+}

--- a/packages/devtools_app/lib/src/bloc/bloc/bloc_list_bloc.dart
+++ b/packages/devtools_app/lib/src/bloc/bloc/bloc_list_bloc.dart
@@ -55,17 +55,9 @@ class BlocListBloc extends Bloc<BlocListEvent, BlocListState> {
     final blocMapRef = await evalOnDartLibrary.safeEval('Bloc.observer.blocMap',
         isAlive: isAlive);
     final blocMap = await evalOnDartLibrary.getInstance(blocMapRef, isAlive);
-    final List<BlocNode> blocs = [];
-    for (var element in blocMap.associations) {
-      final keyResult = element.key;
-      final valueResult = element.value;
-      if (keyResult is! Sentinel && valueResult is! Sentinel) {
-        final elementId = element.key.valueAsString;
-        final elementType = element.value.classRef.name;
-        final BlocNode next = BlocNode(elementId, elementType);
-        blocs.add(next);
-      }
-    }
-    return blocs;
+    return blocMap.associates
+      .where((a) => a.key is! Sentinel && a.value is! Sentinel)
+      .map((a) => BlocNode(a.key.valueAsString, a.value.classRef.name))
+      .toList();
   }
 }

--- a/packages/devtools_app/lib/src/bloc/bloc/bloc_list_event.dart
+++ b/packages/devtools_app/lib/src/bloc/bloc/bloc_list_event.dart
@@ -18,4 +18,6 @@ class BlocSelected extends BlocListEvent {
   List<Object> get props => [selectedBlocId];
 }
 
-class BlocListUpdated extends BlocListEvent {}
+class BlocListUpdated extends BlocListEvent {
+  const BlocListUpdated();
+}

--- a/packages/devtools_app/lib/src/bloc/bloc/bloc_list_event.dart
+++ b/packages/devtools_app/lib/src/bloc/bloc/bloc_list_event.dart
@@ -1,10 +1,5 @@
-import 'package:equatable/equatable.dart';
-
-abstract class BlocListEvent extends Equatable {
+abstract class BlocListEvent {
   const BlocListEvent();
-
-  @override
-  List<Object> get props => [];
 }
 
 class BlocListRequested extends BlocListEvent {}
@@ -13,9 +8,6 @@ class BlocSelected extends BlocListEvent {
   const BlocSelected(this.selectedBlocId);
 
   final String selectedBlocId;
-
-  @override
-  List<Object> get props => [selectedBlocId];
 }
 
 class BlocListUpdated extends BlocListEvent {

--- a/packages/devtools_app/lib/src/bloc/bloc/bloc_list_event.dart
+++ b/packages/devtools_app/lib/src/bloc/bloc/bloc_list_event.dart
@@ -1,0 +1,21 @@
+import 'package:equatable/equatable.dart';
+
+abstract class BlocListEvent extends Equatable {
+  const BlocListEvent();
+
+  @override
+  List<Object> get props => [];
+}
+
+class BlocListRequested extends BlocListEvent {}
+
+class BlocSelected extends BlocListEvent {
+  const BlocSelected(this.selectedBlocId);
+
+  final String selectedBlocId;
+
+  @override
+  List<Object> get props => [selectedBlocId];
+}
+
+class BlocListUpdated extends BlocListEvent {}

--- a/packages/devtools_app/lib/src/bloc/bloc/bloc_list_state.dart
+++ b/packages/devtools_app/lib/src/bloc/bloc/bloc_list_state.dart
@@ -1,0 +1,24 @@
+// ignore: implementation_imports
+import '../models/bloc_node.dart';
+
+enum BlocListStatus { initial, loading, success, failure }
+
+class BlocListState {
+  const BlocListState({
+    this.blocs = const [],
+    this.status = BlocListStatus.loading,
+  }) : assert(blocs != null);
+
+  final List<BlocNode> blocs;
+  final BlocListStatus status;
+
+  BlocListState copyWith({
+    List<BlocNode> blocs,
+    BlocListStatus status,
+  }) {
+    return BlocListState(
+      blocs: blocs ?? this.blocs,
+      status: status ?? this.status,
+    );
+  }
+}

--- a/packages/devtools_app/lib/src/bloc/bloc/bloc_list_state.dart
+++ b/packages/devtools_app/lib/src/bloc/bloc/bloc_list_state.dart
@@ -1,4 +1,3 @@
-// ignore: implementation_imports
 import '../models/bloc_node.dart';
 
 enum BlocListStatus { initial, loading, success, failure }

--- a/packages/devtools_app/lib/src/bloc/bloc/bloc_node_bloc.dart
+++ b/packages/devtools_app/lib/src/bloc/bloc/bloc_node_bloc.dart
@@ -48,7 +48,7 @@ class BlocNodeBloc extends Bloc<BlocListEvent, BlocNodeState> {
     try {
       final Instance blocState = await _getBlocState(event.selectedBlocId);
       yield state.copyWith(
-          selectedBlocId: event.selectedBlocId, selectedBlocState: blocState);
+          selectedBlocId: event.selectedBlocId, selectedBlocState: blocState,);
     } catch (_) {}
   }
 

--- a/packages/devtools_app/lib/src/bloc/bloc/bloc_node_bloc.dart
+++ b/packages/devtools_app/lib/src/bloc/bloc/bloc_node_bloc.dart
@@ -39,7 +39,7 @@ class BlocNodeBloc extends Bloc<BlocListEvent, BlocNodeState> {
       try {
         final Instance blocState = await _getBlocState(state.selectedBlocId);
         yield state.copyWith(
-            selectedBlocId: state.selectedBlocId, selectedBlocState: blocState);
+            selectedBlocId: state.selectedBlocId, selectedBlocState: blocState,);
       } catch (_) {}
     }
   }

--- a/packages/devtools_app/lib/src/bloc/bloc/bloc_node_bloc.dart
+++ b/packages/devtools_app/lib/src/bloc/bloc/bloc_node_bloc.dart
@@ -49,9 +49,7 @@ class BlocNodeBloc extends Bloc<BlocListEvent, BlocNodeState> {
       final Instance blocState = await _getBlocState(event.selectedBlocId);
       yield state.copyWith(
           selectedBlocId: event.selectedBlocId, selectedBlocState: blocState);
-    } catch (e) {
-      print(e);
-    }
+    } catch (_) {}
   }
 
 

--- a/packages/devtools_app/lib/src/bloc/bloc/bloc_node_bloc.dart
+++ b/packages/devtools_app/lib/src/bloc/bloc/bloc_node_bloc.dart
@@ -1,0 +1,71 @@
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
+import 'package:vm_service/vm_service.dart';
+
+import '../../eval_on_dart_library.dart';
+
+import 'bloc_list_event.dart';
+import 'bloc_node_state.dart';
+
+class BlocNodeBloc extends Bloc<BlocListEvent, BlocNodeState> {
+  BlocNodeBloc(
+    this.evalOnDartLibrary,
+    this.service
+  ) : super(const BlocNodeState()) {
+    subscription = service.onExtensionEvent.where((event) {
+      return event.extensionKind == 'bloc:bloc_map_changed';
+    }).listen((_) => add(BlocListUpdated()));
+  }
+  StreamSubscription subscription;
+  final VmService service;
+  final EvalOnDartLibrary evalOnDartLibrary;
+  final isAlive = Disposable();
+
+  @override
+  Future<void> close() {
+    subscription.cancel();
+    return super.close();
+  }
+
+  @override
+  Stream<BlocNodeState> mapEventToState(
+    BlocListEvent event,
+  ) async* {
+    if (event is BlocSelected) {
+      yield* _mapBlocSelectedToState(event);
+    } else if (event is BlocListUpdated) {
+      if (state.selectedBlocId == null) return;
+      try {
+        final Instance blocState = await _getBlocState(state.selectedBlocId);
+        yield state.copyWith(
+            selectedBlocId: state.selectedBlocId, selectedBlocState: blocState);
+      } catch (e) {
+        print(e);
+      }
+    }
+  }
+
+  Stream<BlocNodeState> _mapBlocSelectedToState(BlocSelected event) async* {
+    try {
+      final Instance blocState = await _getBlocState(event.selectedBlocId);
+      yield state.copyWith(
+          selectedBlocId: event.selectedBlocId, selectedBlocState: blocState);
+    } catch (e) {
+      print(e);
+    }
+  }
+
+
+  // Returns an Instance of the state object for the bloc that maps to selectedBlocId
+  Future<Instance> _getBlocState(String selectedBlocId) async {
+    final blocStateRef = await evalOnDartLibrary.eval(
+        'Bloc.observer.blocMap["$selectedBlocId"]?.state',
+        isAlive: isAlive);
+    final blocState =
+        await evalOnDartLibrary.getInstance(blocStateRef, isAlive);
+
+    return blocState;
+  }
+
+}

--- a/packages/devtools_app/lib/src/bloc/bloc/bloc_node_bloc.dart
+++ b/packages/devtools_app/lib/src/bloc/bloc/bloc_node_bloc.dart
@@ -40,9 +40,7 @@ class BlocNodeBloc extends Bloc<BlocListEvent, BlocNodeState> {
         final Instance blocState = await _getBlocState(state.selectedBlocId);
         yield state.copyWith(
             selectedBlocId: state.selectedBlocId, selectedBlocState: blocState);
-      } catch (e) {
-        print(e);
-      }
+      } catch (_) {}
     }
   }
 

--- a/packages/devtools_app/lib/src/bloc/bloc/bloc_node_bloc.dart
+++ b/packages/devtools_app/lib/src/bloc/bloc/bloc_node_bloc.dart
@@ -15,7 +15,7 @@ class BlocNodeBloc extends Bloc<BlocListEvent, BlocNodeState> {
   ) : super(const BlocNodeState()) {
     subscription = service.onExtensionEvent.where((event) {
       return event.extensionKind == 'bloc:bloc_map_changed';
-    }).listen((_) => add(BlocListUpdated()));
+    }).listen((_) => add(const BlocListUpdated()));
   }
   StreamSubscription subscription;
   final VmService service;
@@ -58,6 +58,6 @@ class BlocNodeBloc extends Bloc<BlocListEvent, BlocNodeState> {
     final blocStateRef = await evalOnDartLibrary.eval(
         'Bloc.observer.blocMap["$selectedBlocId"]?.state',
         isAlive: isAlive,);
-    return. evalOnDartLibrary.getInstance(blocStateRef, isAlive);
+    return evalOnDartLibrary.getInstance(blocStateRef, isAlive);
   }
 }

--- a/packages/devtools_app/lib/src/bloc/bloc/bloc_node_bloc.dart
+++ b/packages/devtools_app/lib/src/bloc/bloc/bloc_node_bloc.dart
@@ -58,9 +58,6 @@ class BlocNodeBloc extends Bloc<BlocListEvent, BlocNodeState> {
     final blocStateRef = await evalOnDartLibrary.eval(
         'Bloc.observer.blocMap["$selectedBlocId"]?.state',
         isAlive: isAlive,);
-    final blocState =
-        await evalOnDartLibrary.getInstance(blocStateRef, isAlive);
-
-    return blocState;
+    return. evalOnDartLibrary.getInstance(blocStateRef, isAlive);
   }
 }

--- a/packages/devtools_app/lib/src/bloc/bloc/bloc_node_bloc.dart
+++ b/packages/devtools_app/lib/src/bloc/bloc/bloc_node_bloc.dart
@@ -57,7 +57,7 @@ class BlocNodeBloc extends Bloc<BlocListEvent, BlocNodeState> {
   Future<Instance> _getBlocState(String selectedBlocId) async {
     final blocStateRef = await evalOnDartLibrary.eval(
         'Bloc.observer.blocMap["$selectedBlocId"]?.state',
-        isAlive: isAlive);
+        isAlive: isAlive,);
     final blocState =
         await evalOnDartLibrary.getInstance(blocStateRef, isAlive);
 

--- a/packages/devtools_app/lib/src/bloc/bloc/bloc_node_bloc.dart
+++ b/packages/devtools_app/lib/src/bloc/bloc/bloc_node_bloc.dart
@@ -63,5 +63,4 @@ class BlocNodeBloc extends Bloc<BlocListEvent, BlocNodeState> {
 
     return blocState;
   }
-
 }

--- a/packages/devtools_app/lib/src/bloc/bloc/bloc_node_state.dart
+++ b/packages/devtools_app/lib/src/bloc/bloc/bloc_node_state.dart
@@ -1,0 +1,18 @@
+import 'package:vm_service/src/vm_service.dart';
+
+class BlocNodeState {
+  const BlocNodeState({this.selectedBlocId, this.selectedBlocState});
+
+  final String selectedBlocId;
+  final Instance selectedBlocState;
+
+  BlocNodeState copyWith({
+    String selectedBlocId,
+    Instance selectedBlocState,
+  }) {
+    return BlocNodeState(
+      selectedBlocId: selectedBlocId ?? this.selectedBlocId,
+      selectedBlocState: selectedBlocState ?? this.selectedBlocState,
+    );
+  }
+}

--- a/packages/devtools_app/lib/src/bloc/instance_viewer/eval.dart
+++ b/packages/devtools_app/lib/src/bloc/instance_viewer/eval.dart
@@ -1,0 +1,46 @@
+// Copyright 2021 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// A few utilities related to evaluating dart code
+library eval;
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../eval_on_dart_library.dart';
+import '../../globals.dart';
+import '../../vm_service_wrapper.dart';
+
+/// Exposes the current VmServiceWrapper.
+/// By listening to this provider instead of directly accessing `serviceManager.service`,
+/// this ensures that providers reload properly when the devtool is connected
+/// to a different application.
+final serviceProvider = StreamProvider<VmServiceWrapper>((ref) async* {
+  yield serviceManager.service;
+  yield* serviceManager.onConnectionAvailable;
+});
+
+/// An [EvalOnDartLibrary] that has access to no specific library in particular
+///
+/// Not suitable to be used when evaluating third-party objects, as it would
+/// otherwise not be possible to read private properties.
+final evalProvider = libraryEvalProvider('dart:io');
+
+final blocEvalProvider = libraryEvalProvider('package:bloc/src/bloc_observer.dart');
+/// An [EvalOnDartLibrary] that has access to `provider`
+final providerEvalProvider =
+    libraryEvalProvider('package:provider/src/provider.dart');
+
+/// An [EvalOnDartLibrary] for custom objects.
+final libraryEvalProvider =
+    FutureProviderFamily<EvalOnDartLibrary, String>((ref, libraryPath) async {
+  final service = await ref.watch(serviceProvider.last);
+
+  final eval = EvalOnDartLibrary([libraryPath], service);
+  ref.onDispose(eval.dispose);
+  return eval;
+});
+
+final hotRestartEventProvider = AutoDisposeStreamProvider<void>((ref) {
+  return serviceManager.isolateManager.onSelectedIsolateChanged;
+});

--- a/packages/devtools_app/lib/src/bloc/instance_viewer/fake_freezed_annotation.dart
+++ b/packages/devtools_app/lib/src/bloc/instance_viewer/fake_freezed_annotation.dart
@@ -1,0 +1,26 @@
+// Copyright 2021 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// This file contains annotations that behaves like package:freezed_annotation.
+// This allows using Freezed without having the devtool depend on the package.
+// We could instead remove the annotations, but that would make the process of
+// updating the generated files tedious.
+
+const nullable = Object();
+const freezed = Object();
+
+class Default {
+  const Default(Object value);
+}
+
+class Assert {
+  const Assert(String exp);
+}
+
+class JsonKey {
+  const JsonKey({
+    bool ignore,
+    Object defaultValue,
+  });
+}

--- a/packages/devtools_app/lib/src/bloc/instance_viewer/instance_details.dart
+++ b/packages/devtools_app/lib/src/bloc/instance_viewer/instance_details.dart
@@ -1,0 +1,196 @@
+// Copyright 2021 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:collection/collection.dart';
+import 'package:meta/meta.dart';
+import 'package:vm_service/vm_service.dart';
+
+import '../../eval_on_dart_library.dart';
+import 'fake_freezed_annotation.dart';
+import 'result.dart';
+
+// This part is generated using package:freezed, but without the devtool depending
+// on the package.
+// To update the generated files, temporarily add freezed/freezed_annotation/build_runner
+// as dependencies; replace the `fake_freezed_annotation.dart` import with the
+// real annotation package, then execute `pub run build_runner build`.
+part 'instance_details.freezed.dart';
+
+typedef Setter = Future<void> Function(String newValue);
+
+@freezed
+abstract class PathToProperty with _$PathToProperty {
+  const factory PathToProperty.listIndex(int index) = ListIndexPath;
+
+  // TODO test that mutating a Map does not collapse previously expanded keys
+  const factory PathToProperty.mapKey({
+    @required @nullable String ref,
+  }) = MapKeyPath;
+
+  /// Must not depend on [InstanceRef] and its ID, as they may change across
+  /// re-evaluations of the object.
+  /// Depending on those would lead to the UI collapsing previously expanded objects
+  /// because the new path to a property would be different.
+  ///
+  /// We can't just rely on the property name either, because in some cases
+  /// an object can have multiple properties with the same name (private properties
+  /// defined in different libraries)
+  const factory PathToProperty.objectProperty({
+    @required String name,
+
+    /// Path to the class/mixin that defined this property
+    @required String ownerUri,
+
+    /// Name of the class/mixin that defined this property
+    @required String ownerName,
+  }) = PropertyPath;
+
+  factory PathToProperty.fromObjectField(ObjectField field) {
+    return PathToProperty.objectProperty(
+      name: field.name,
+      ownerUri: field.ownerUri,
+      ownerName: field.ownerName,
+    );
+  }
+}
+
+@freezed
+abstract class ObjectField with _$ObjectField {
+  factory ObjectField({
+    @required String name,
+    @required bool isFinal,
+    @required String ownerName,
+    @required String ownerUri,
+    @required @nullable Result<InstanceRef> ref,
+
+    /// An [EvalOnDartLibrary] that can access this field from the owner object
+    @required EvalOnDartLibrary eval,
+
+    /// Whether this field was defined by the inspected app or by one of its dependencies
+    ///
+    /// This is used by the UI to hide variables that are not useful for the user.
+    @required bool isDefinedByDependency,
+  }) = _ObjectField;
+
+  ObjectField._();
+
+  bool get isPrivate => name.startsWith('_');
+}
+
+@freezed
+abstract class InstanceDetails with _$InstanceDetails {
+  InstanceDetails._();
+
+  @Assert('instanceRefId == null')
+  factory InstanceDetails.nill({
+    String instanceRefId,
+    @required @nullable Setter setter,
+  }) = NullInstance;
+
+  factory InstanceDetails.boolean(
+    String displayString, {
+    @required String instanceRefId,
+    @required @nullable Setter setter,
+  }) = BoolInstance;
+
+  factory InstanceDetails.number(
+    String displayString, {
+    @required String instanceRefId,
+    @required @nullable Setter setter,
+  }) = NumInstance;
+
+  factory InstanceDetails.string(
+    String displayString, {
+    @required String instanceRefId,
+    @required @nullable Setter setter,
+  }) = StringInstance;
+
+  factory InstanceDetails.map(
+    List<InstanceDetails> keys, {
+    @required int hash,
+    @required String instanceRefId,
+    @required @nullable Setter setter,
+  }) = MapInstance;
+
+  factory InstanceDetails.list({
+    @required @nullable int length,
+    @required int hash,
+    @required String instanceRefId,
+    @required @nullable Setter setter,
+  }) = ListInstance;
+
+  factory InstanceDetails.object(
+    List<ObjectField> fields, {
+    @required String type,
+    @required int hash,
+    @required String instanceRefId,
+    @required @nullable Setter setter,
+
+    /// An [EvalOnDartLibrary] associated with the library of this object
+    ///
+    /// This allows to edit private properties.
+    @required EvalOnDartLibrary evalForInstance,
+  }) = ObjectInstance;
+
+  factory InstanceDetails.enumeration({
+    @required String type,
+    @required String value,
+    @required @nullable Setter setter,
+    @required String instanceRefId,
+  }) = EnumInstance;
+
+  bool get isExpandable {
+    bool falsy(Object obj) => false;
+
+    return map(
+      nill: falsy,
+      boolean: falsy,
+      number: falsy,
+      string: falsy,
+      enumeration: falsy,
+      map: (instance) => instance.keys.isNotEmpty,
+      list: (instance) => instance.length > 0,
+      object: (instance) => instance.fields.isNotEmpty,
+    );
+  }
+}
+
+/// The path to visit child elements of an [Instance] or providers from `provider`/`riverpod`.
+@freezed
+abstract class InstancePath with _$InstancePath {
+  const InstancePath._();
+
+  const factory InstancePath.fromInstanceId(
+    @nullable String instanceId, {
+    @Default([]) List<PathToProperty> pathToProperty,
+  }) = _InstancePathFromInstanceId;
+
+  const factory InstancePath.fromProviderId(
+    String providerId, {
+    @Default([]) List<PathToProperty> pathToProperty,
+  }) = _InstancePathFromProviderId;
+
+  const factory InstancePath.fromBlocId(
+    String blocId, {
+    @Default([]) List<PathToProperty> pathToProperty,
+  }) = _InstancePathFromBlocId;
+
+  InstancePath get root => copyWith(pathToProperty: []);
+
+  InstancePath get parent {
+    if (pathToProperty.isEmpty) return null;
+
+    return copyWith(
+      pathToProperty: [
+        for (var i = 0; i + 1 < pathToProperty.length; i++) pathToProperty[i],
+      ],
+    );
+  }
+
+  InstancePath pathForChild(PathToProperty property) {
+    return copyWith(
+      pathToProperty: [...pathToProperty, property],
+    );
+  }
+}

--- a/packages/devtools_app/lib/src/bloc/instance_viewer/instance_details.freezed.dart
+++ b/packages/devtools_app/lib/src/bloc/instance_viewer/instance_details.freezed.dart
@@ -1,0 +1,3505 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies
+
+part of 'instance_details.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+class _$PathToPropertyTearOff {
+  const _$PathToPropertyTearOff();
+
+// ignore: unused_element
+  ListIndexPath listIndex(int index) {
+    return ListIndexPath(
+      index,
+    );
+  }
+
+// ignore: unused_element
+  MapKeyPath mapKey({@required @nullable String ref}) {
+    return MapKeyPath(
+      ref: ref,
+    );
+  }
+
+// ignore: unused_element
+  PropertyPath objectProperty(
+      {@required String name,
+      @required String ownerUri,
+      @required String ownerName}) {
+    return PropertyPath(
+      name: name,
+      ownerUri: ownerUri,
+      ownerName: ownerName,
+    );
+  }
+}
+
+/// @nodoc
+// ignore: unused_element
+const $PathToProperty = _$PathToPropertyTearOff();
+
+/// @nodoc
+mixin _$PathToProperty {
+  @optionalTypeArgs
+  TResult when<TResult extends Object>({
+    @required TResult listIndex(int index),
+    @required TResult mapKey(@nullable String ref),
+    @required
+        TResult objectProperty(String name, String ownerUri, String ownerName),
+  });
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object>({
+    TResult listIndex(int index),
+    TResult mapKey(@nullable String ref),
+    TResult objectProperty(String name, String ownerUri, String ownerName),
+    @required TResult orElse(),
+  });
+  @optionalTypeArgs
+  TResult map<TResult extends Object>({
+    @required TResult listIndex(ListIndexPath value),
+    @required TResult mapKey(MapKeyPath value),
+    @required TResult objectProperty(PropertyPath value),
+  });
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object>({
+    TResult listIndex(ListIndexPath value),
+    TResult mapKey(MapKeyPath value),
+    TResult objectProperty(PropertyPath value),
+    @required TResult orElse(),
+  });
+}
+
+/// @nodoc
+abstract class $PathToPropertyCopyWith<$Res> {
+  factory $PathToPropertyCopyWith(
+          PathToProperty value, $Res Function(PathToProperty) then) =
+      _$PathToPropertyCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class _$PathToPropertyCopyWithImpl<$Res>
+    implements $PathToPropertyCopyWith<$Res> {
+  _$PathToPropertyCopyWithImpl(this._value, this._then);
+
+  final PathToProperty _value;
+  // ignore: unused_field
+  final $Res Function(PathToProperty) _then;
+}
+
+/// @nodoc
+abstract class $ListIndexPathCopyWith<$Res> {
+  factory $ListIndexPathCopyWith(
+          ListIndexPath value, $Res Function(ListIndexPath) then) =
+      _$ListIndexPathCopyWithImpl<$Res>;
+  $Res call({int index});
+}
+
+/// @nodoc
+class _$ListIndexPathCopyWithImpl<$Res>
+    extends _$PathToPropertyCopyWithImpl<$Res>
+    implements $ListIndexPathCopyWith<$Res> {
+  _$ListIndexPathCopyWithImpl(
+      ListIndexPath _value, $Res Function(ListIndexPath) _then)
+      : super(_value, (v) => _then(v as ListIndexPath));
+
+  @override
+  ListIndexPath get _value => super._value as ListIndexPath;
+
+  @override
+  $Res call({
+    Object index = freezed,
+  }) {
+    return _then(ListIndexPath(
+      index == freezed ? _value.index : index as int,
+    ));
+  }
+}
+
+/// @nodoc
+class _$ListIndexPath implements ListIndexPath {
+  const _$ListIndexPath(this.index) : assert(index != null);
+
+  @override
+  final int index;
+
+  @override
+  String toString() {
+    return 'PathToProperty.listIndex(index: $index)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other is ListIndexPath &&
+            (identical(other.index, index) ||
+                const DeepCollectionEquality().equals(other.index, index)));
+  }
+
+  @override
+  int get hashCode =>
+      runtimeType.hashCode ^ const DeepCollectionEquality().hash(index);
+
+  @JsonKey(ignore: true)
+  @override
+  $ListIndexPathCopyWith<ListIndexPath> get copyWith =>
+      _$ListIndexPathCopyWithImpl<ListIndexPath>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object>({
+    @required TResult listIndex(int index),
+    @required TResult mapKey(@nullable String ref),
+    @required
+        TResult objectProperty(String name, String ownerUri, String ownerName),
+  }) {
+    assert(listIndex != null);
+    assert(mapKey != null);
+    assert(objectProperty != null);
+    return listIndex(index);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object>({
+    TResult listIndex(int index),
+    TResult mapKey(@nullable String ref),
+    TResult objectProperty(String name, String ownerUri, String ownerName),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (listIndex != null) {
+      return listIndex(index);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object>({
+    @required TResult listIndex(ListIndexPath value),
+    @required TResult mapKey(MapKeyPath value),
+    @required TResult objectProperty(PropertyPath value),
+  }) {
+    assert(listIndex != null);
+    assert(mapKey != null);
+    assert(objectProperty != null);
+    return listIndex(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object>({
+    TResult listIndex(ListIndexPath value),
+    TResult mapKey(MapKeyPath value),
+    TResult objectProperty(PropertyPath value),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (listIndex != null) {
+      return listIndex(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class ListIndexPath implements PathToProperty {
+  const factory ListIndexPath(int index) = _$ListIndexPath;
+
+  int get index;
+  @JsonKey(ignore: true)
+  $ListIndexPathCopyWith<ListIndexPath> get copyWith;
+}
+
+/// @nodoc
+abstract class $MapKeyPathCopyWith<$Res> {
+  factory $MapKeyPathCopyWith(
+          MapKeyPath value, $Res Function(MapKeyPath) then) =
+      _$MapKeyPathCopyWithImpl<$Res>;
+  $Res call({@nullable String ref});
+}
+
+/// @nodoc
+class _$MapKeyPathCopyWithImpl<$Res> extends _$PathToPropertyCopyWithImpl<$Res>
+    implements $MapKeyPathCopyWith<$Res> {
+  _$MapKeyPathCopyWithImpl(MapKeyPath _value, $Res Function(MapKeyPath) _then)
+      : super(_value, (v) => _then(v as MapKeyPath));
+
+  @override
+  MapKeyPath get _value => super._value as MapKeyPath;
+
+  @override
+  $Res call({
+    Object ref = freezed,
+  }) {
+    return _then(MapKeyPath(
+      ref: ref == freezed ? _value.ref : ref as String,
+    ));
+  }
+}
+
+/// @nodoc
+class _$MapKeyPath implements MapKeyPath {
+  const _$MapKeyPath({@required @nullable this.ref});
+
+  @override
+  @nullable
+  final String ref;
+
+  @override
+  String toString() {
+    return 'PathToProperty.mapKey(ref: $ref)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other is MapKeyPath &&
+            (identical(other.ref, ref) ||
+                const DeepCollectionEquality().equals(other.ref, ref)));
+  }
+
+  @override
+  int get hashCode =>
+      runtimeType.hashCode ^ const DeepCollectionEquality().hash(ref);
+
+  @JsonKey(ignore: true)
+  @override
+  $MapKeyPathCopyWith<MapKeyPath> get copyWith =>
+      _$MapKeyPathCopyWithImpl<MapKeyPath>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object>({
+    @required TResult listIndex(int index),
+    @required TResult mapKey(@nullable String ref),
+    @required
+        TResult objectProperty(String name, String ownerUri, String ownerName),
+  }) {
+    assert(listIndex != null);
+    assert(mapKey != null);
+    assert(objectProperty != null);
+    return mapKey(ref);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object>({
+    TResult listIndex(int index),
+    TResult mapKey(@nullable String ref),
+    TResult objectProperty(String name, String ownerUri, String ownerName),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (mapKey != null) {
+      return mapKey(ref);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object>({
+    @required TResult listIndex(ListIndexPath value),
+    @required TResult mapKey(MapKeyPath value),
+    @required TResult objectProperty(PropertyPath value),
+  }) {
+    assert(listIndex != null);
+    assert(mapKey != null);
+    assert(objectProperty != null);
+    return mapKey(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object>({
+    TResult listIndex(ListIndexPath value),
+    TResult mapKey(MapKeyPath value),
+    TResult objectProperty(PropertyPath value),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (mapKey != null) {
+      return mapKey(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class MapKeyPath implements PathToProperty {
+  const factory MapKeyPath({@required @nullable String ref}) = _$MapKeyPath;
+
+  @nullable
+  String get ref;
+  @JsonKey(ignore: true)
+  $MapKeyPathCopyWith<MapKeyPath> get copyWith;
+}
+
+/// @nodoc
+abstract class $PropertyPathCopyWith<$Res> {
+  factory $PropertyPathCopyWith(
+          PropertyPath value, $Res Function(PropertyPath) then) =
+      _$PropertyPathCopyWithImpl<$Res>;
+  $Res call({String name, String ownerUri, String ownerName});
+}
+
+/// @nodoc
+class _$PropertyPathCopyWithImpl<$Res>
+    extends _$PathToPropertyCopyWithImpl<$Res>
+    implements $PropertyPathCopyWith<$Res> {
+  _$PropertyPathCopyWithImpl(
+      PropertyPath _value, $Res Function(PropertyPath) _then)
+      : super(_value, (v) => _then(v as PropertyPath));
+
+  @override
+  PropertyPath get _value => super._value as PropertyPath;
+
+  @override
+  $Res call({
+    Object name = freezed,
+    Object ownerUri = freezed,
+    Object ownerName = freezed,
+  }) {
+    return _then(PropertyPath(
+      name: name == freezed ? _value.name : name as String,
+      ownerUri: ownerUri == freezed ? _value.ownerUri : ownerUri as String,
+      ownerName: ownerName == freezed ? _value.ownerName : ownerName as String,
+    ));
+  }
+}
+
+/// @nodoc
+class _$PropertyPath implements PropertyPath {
+  const _$PropertyPath(
+      {@required this.name, @required this.ownerUri, @required this.ownerName})
+      : assert(name != null),
+        assert(ownerUri != null),
+        assert(ownerName != null);
+
+  @override
+  final String name;
+  @override
+
+  /// Path to the class/mixin that defined this property
+  final String ownerUri;
+  @override
+
+  /// Name of the class/mixin that defined this property
+  final String ownerName;
+
+  @override
+  String toString() {
+    return 'PathToProperty.objectProperty(name: $name, ownerUri: $ownerUri, ownerName: $ownerName)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other is PropertyPath &&
+            (identical(other.name, name) ||
+                const DeepCollectionEquality().equals(other.name, name)) &&
+            (identical(other.ownerUri, ownerUri) ||
+                const DeepCollectionEquality()
+                    .equals(other.ownerUri, ownerUri)) &&
+            (identical(other.ownerName, ownerName) ||
+                const DeepCollectionEquality()
+                    .equals(other.ownerName, ownerName)));
+  }
+
+  @override
+  int get hashCode =>
+      runtimeType.hashCode ^
+      const DeepCollectionEquality().hash(name) ^
+      const DeepCollectionEquality().hash(ownerUri) ^
+      const DeepCollectionEquality().hash(ownerName);
+
+  @JsonKey(ignore: true)
+  @override
+  $PropertyPathCopyWith<PropertyPath> get copyWith =>
+      _$PropertyPathCopyWithImpl<PropertyPath>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object>({
+    @required TResult listIndex(int index),
+    @required TResult mapKey(@nullable String ref),
+    @required
+        TResult objectProperty(String name, String ownerUri, String ownerName),
+  }) {
+    assert(listIndex != null);
+    assert(mapKey != null);
+    assert(objectProperty != null);
+    return objectProperty(name, ownerUri, ownerName);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object>({
+    TResult listIndex(int index),
+    TResult mapKey(@nullable String ref),
+    TResult objectProperty(String name, String ownerUri, String ownerName),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (objectProperty != null) {
+      return objectProperty(name, ownerUri, ownerName);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object>({
+    @required TResult listIndex(ListIndexPath value),
+    @required TResult mapKey(MapKeyPath value),
+    @required TResult objectProperty(PropertyPath value),
+  }) {
+    assert(listIndex != null);
+    assert(mapKey != null);
+    assert(objectProperty != null);
+    return objectProperty(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object>({
+    TResult listIndex(ListIndexPath value),
+    TResult mapKey(MapKeyPath value),
+    TResult objectProperty(PropertyPath value),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (objectProperty != null) {
+      return objectProperty(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class PropertyPath implements PathToProperty {
+  const factory PropertyPath(
+      {@required String name,
+      @required String ownerUri,
+      @required String ownerName}) = _$PropertyPath;
+
+  String get name;
+
+  /// Path to the class/mixin that defined this property
+  String get ownerUri;
+
+  /// Name of the class/mixin that defined this property
+  String get ownerName;
+  @JsonKey(ignore: true)
+  $PropertyPathCopyWith<PropertyPath> get copyWith;
+}
+
+/// @nodoc
+class _$ObjectFieldTearOff {
+  const _$ObjectFieldTearOff();
+
+// ignore: unused_element
+  _ObjectField call(
+      {@required String name,
+      @required bool isFinal,
+      @required String ownerName,
+      @required String ownerUri,
+      @required @nullable Result<InstanceRef> ref,
+      @required EvalOnDartLibrary eval,
+      @required bool isDefinedByDependency}) {
+    return _ObjectField(
+      name: name,
+      isFinal: isFinal,
+      ownerName: ownerName,
+      ownerUri: ownerUri,
+      ref: ref,
+      eval: eval,
+      isDefinedByDependency: isDefinedByDependency,
+    );
+  }
+}
+
+/// @nodoc
+// ignore: unused_element
+const $ObjectField = _$ObjectFieldTearOff();
+
+/// @nodoc
+mixin _$ObjectField {
+  String get name;
+  bool get isFinal;
+  String get ownerName;
+  String get ownerUri;
+  @nullable
+  Result<InstanceRef> get ref;
+
+  /// An [EvalOnDartLibrary] that can access this field from the owner object
+  EvalOnDartLibrary get eval;
+
+  /// Whether this field was defined by the inspected app or by one of its dependencies
+  ///
+  /// This is used by the UI to hide variables that are not useful for the user.
+  bool get isDefinedByDependency;
+
+  @JsonKey(ignore: true)
+  $ObjectFieldCopyWith<ObjectField> get copyWith;
+}
+
+/// @nodoc
+abstract class $ObjectFieldCopyWith<$Res> {
+  factory $ObjectFieldCopyWith(
+          ObjectField value, $Res Function(ObjectField) then) =
+      _$ObjectFieldCopyWithImpl<$Res>;
+  $Res call(
+      {String name,
+      bool isFinal,
+      String ownerName,
+      String ownerUri,
+      @nullable Result<InstanceRef> ref,
+      EvalOnDartLibrary eval,
+      bool isDefinedByDependency});
+}
+
+/// @nodoc
+class _$ObjectFieldCopyWithImpl<$Res> implements $ObjectFieldCopyWith<$Res> {
+  _$ObjectFieldCopyWithImpl(this._value, this._then);
+
+  final ObjectField _value;
+  // ignore: unused_field
+  final $Res Function(ObjectField) _then;
+
+  @override
+  $Res call({
+    Object name = freezed,
+    Object isFinal = freezed,
+    Object ownerName = freezed,
+    Object ownerUri = freezed,
+    Object ref = freezed,
+    Object eval = freezed,
+    Object isDefinedByDependency = freezed,
+  }) {
+    return _then(_value.copyWith(
+      name: name == freezed ? _value.name : name as String,
+      isFinal: isFinal == freezed ? _value.isFinal : isFinal as bool,
+      ownerName: ownerName == freezed ? _value.ownerName : ownerName as String,
+      ownerUri: ownerUri == freezed ? _value.ownerUri : ownerUri as String,
+      ref: ref == freezed ? _value.ref : ref as Result<InstanceRef>,
+      eval: eval == freezed ? _value.eval : eval as EvalOnDartLibrary,
+      isDefinedByDependency: isDefinedByDependency == freezed
+          ? _value.isDefinedByDependency
+          : isDefinedByDependency as bool,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$ObjectFieldCopyWith<$Res>
+    implements $ObjectFieldCopyWith<$Res> {
+  factory _$ObjectFieldCopyWith(
+          _ObjectField value, $Res Function(_ObjectField) then) =
+      __$ObjectFieldCopyWithImpl<$Res>;
+  @override
+  $Res call(
+      {String name,
+      bool isFinal,
+      String ownerName,
+      String ownerUri,
+      @nullable Result<InstanceRef> ref,
+      EvalOnDartLibrary eval,
+      bool isDefinedByDependency});
+}
+
+/// @nodoc
+class __$ObjectFieldCopyWithImpl<$Res> extends _$ObjectFieldCopyWithImpl<$Res>
+    implements _$ObjectFieldCopyWith<$Res> {
+  __$ObjectFieldCopyWithImpl(
+      _ObjectField _value, $Res Function(_ObjectField) _then)
+      : super(_value, (v) => _then(v as _ObjectField));
+
+  @override
+  _ObjectField get _value => super._value as _ObjectField;
+
+  @override
+  $Res call({
+    Object name = freezed,
+    Object isFinal = freezed,
+    Object ownerName = freezed,
+    Object ownerUri = freezed,
+    Object ref = freezed,
+    Object eval = freezed,
+    Object isDefinedByDependency = freezed,
+  }) {
+    return _then(_ObjectField(
+      name: name == freezed ? _value.name : name as String,
+      isFinal: isFinal == freezed ? _value.isFinal : isFinal as bool,
+      ownerName: ownerName == freezed ? _value.ownerName : ownerName as String,
+      ownerUri: ownerUri == freezed ? _value.ownerUri : ownerUri as String,
+      ref: ref == freezed ? _value.ref : ref as Result<InstanceRef>,
+      eval: eval == freezed ? _value.eval : eval as EvalOnDartLibrary,
+      isDefinedByDependency: isDefinedByDependency == freezed
+          ? _value.isDefinedByDependency
+          : isDefinedByDependency as bool,
+    ));
+  }
+}
+
+/// @nodoc
+class _$_ObjectField extends _ObjectField {
+  _$_ObjectField(
+      {@required this.name,
+      @required this.isFinal,
+      @required this.ownerName,
+      @required this.ownerUri,
+      @required @nullable this.ref,
+      @required this.eval,
+      @required this.isDefinedByDependency})
+      : assert(name != null),
+        assert(isFinal != null),
+        assert(ownerName != null),
+        assert(ownerUri != null),
+        assert(eval != null),
+        assert(isDefinedByDependency != null),
+        super._();
+
+  @override
+  final String name;
+  @override
+  final bool isFinal;
+  @override
+  final String ownerName;
+  @override
+  final String ownerUri;
+  @override
+  @nullable
+  final Result<InstanceRef> ref;
+  @override
+
+  /// An [EvalOnDartLibrary] that can access this field from the owner object
+  final EvalOnDartLibrary eval;
+  @override
+
+  /// Whether this field was defined by the inspected app or by one of its dependencies
+  ///
+  /// This is used by the UI to hide variables that are not useful for the user.
+  final bool isDefinedByDependency;
+
+  @override
+  String toString() {
+    return 'ObjectField(name: $name, isFinal: $isFinal, ownerName: $ownerName, ownerUri: $ownerUri, ref: $ref, eval: $eval, isDefinedByDependency: $isDefinedByDependency)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other is _ObjectField &&
+            (identical(other.name, name) ||
+                const DeepCollectionEquality().equals(other.name, name)) &&
+            (identical(other.isFinal, isFinal) ||
+                const DeepCollectionEquality()
+                    .equals(other.isFinal, isFinal)) &&
+            (identical(other.ownerName, ownerName) ||
+                const DeepCollectionEquality()
+                    .equals(other.ownerName, ownerName)) &&
+            (identical(other.ownerUri, ownerUri) ||
+                const DeepCollectionEquality()
+                    .equals(other.ownerUri, ownerUri)) &&
+            (identical(other.ref, ref) ||
+                const DeepCollectionEquality().equals(other.ref, ref)) &&
+            (identical(other.eval, eval) ||
+                const DeepCollectionEquality().equals(other.eval, eval)) &&
+            (identical(other.isDefinedByDependency, isDefinedByDependency) ||
+                const DeepCollectionEquality().equals(
+                    other.isDefinedByDependency, isDefinedByDependency)));
+  }
+
+  @override
+  int get hashCode =>
+      runtimeType.hashCode ^
+      const DeepCollectionEquality().hash(name) ^
+      const DeepCollectionEquality().hash(isFinal) ^
+      const DeepCollectionEquality().hash(ownerName) ^
+      const DeepCollectionEquality().hash(ownerUri) ^
+      const DeepCollectionEquality().hash(ref) ^
+      const DeepCollectionEquality().hash(eval) ^
+      const DeepCollectionEquality().hash(isDefinedByDependency);
+
+  @JsonKey(ignore: true)
+  @override
+  _$ObjectFieldCopyWith<_ObjectField> get copyWith =>
+      __$ObjectFieldCopyWithImpl<_ObjectField>(this, _$identity);
+}
+
+abstract class _ObjectField extends ObjectField {
+  _ObjectField._() : super._();
+  factory _ObjectField(
+      {@required String name,
+      @required bool isFinal,
+      @required String ownerName,
+      @required String ownerUri,
+      @required @nullable Result<InstanceRef> ref,
+      @required EvalOnDartLibrary eval,
+      @required bool isDefinedByDependency}) = _$_ObjectField;
+
+  @override
+  String get name;
+  @override
+  bool get isFinal;
+  @override
+  String get ownerName;
+  @override
+  String get ownerUri;
+  @override
+  @nullable
+  Result<InstanceRef> get ref;
+  @override
+
+  /// An [EvalOnDartLibrary] that can access this field from the owner object
+  EvalOnDartLibrary get eval;
+  @override
+
+  /// Whether this field was defined by the inspected app or by one of its dependencies
+  ///
+  /// This is used by the UI to hide variables that are not useful for the user.
+  bool get isDefinedByDependency;
+  @override
+  @JsonKey(ignore: true)
+  _$ObjectFieldCopyWith<_ObjectField> get copyWith;
+}
+
+/// @nodoc
+class _$InstanceDetailsTearOff {
+  const _$InstanceDetailsTearOff();
+
+// ignore: unused_element
+  NullInstance nill(
+      {String instanceRefId,
+      @required @nullable Future<void> Function(String) setter}) {
+    return NullInstance(
+      instanceRefId: instanceRefId,
+      setter: setter,
+    );
+  }
+
+// ignore: unused_element
+  BoolInstance boolean(String displayString,
+      {@required String instanceRefId,
+      @required @nullable Future<void> Function(String) setter}) {
+    return BoolInstance(
+      displayString,
+      instanceRefId: instanceRefId,
+      setter: setter,
+    );
+  }
+
+// ignore: unused_element
+  NumInstance number(String displayString,
+      {@required String instanceRefId,
+      @required @nullable Future<void> Function(String) setter}) {
+    return NumInstance(
+      displayString,
+      instanceRefId: instanceRefId,
+      setter: setter,
+    );
+  }
+
+// ignore: unused_element
+  StringInstance string(String displayString,
+      {@required String instanceRefId,
+      @required @nullable Future<void> Function(String) setter}) {
+    return StringInstance(
+      displayString,
+      instanceRefId: instanceRefId,
+      setter: setter,
+    );
+  }
+
+// ignore: unused_element
+  MapInstance map(List<InstanceDetails> keys,
+      {@required int hash,
+      @required String instanceRefId,
+      @required @nullable Future<void> Function(String) setter}) {
+    return MapInstance(
+      keys,
+      hash: hash,
+      instanceRefId: instanceRefId,
+      setter: setter,
+    );
+  }
+
+// ignore: unused_element
+  ListInstance list(
+      {@required @nullable int length,
+      @required int hash,
+      @required String instanceRefId,
+      @required @nullable Future<void> Function(String) setter}) {
+    return ListInstance(
+      length: length,
+      hash: hash,
+      instanceRefId: instanceRefId,
+      setter: setter,
+    );
+  }
+
+// ignore: unused_element
+  ObjectInstance object(List<ObjectField> fields,
+      {@required String type,
+      @required int hash,
+      @required String instanceRefId,
+      @required @nullable Future<void> Function(String) setter,
+      @required EvalOnDartLibrary evalForInstance}) {
+    return ObjectInstance(
+      fields,
+      type: type,
+      hash: hash,
+      instanceRefId: instanceRefId,
+      setter: setter,
+      evalForInstance: evalForInstance,
+    );
+  }
+
+// ignore: unused_element
+  EnumInstance enumeration(
+      {@required String type,
+      @required String value,
+      @required @nullable Future<void> Function(String) setter,
+      @required String instanceRefId}) {
+    return EnumInstance(
+      type: type,
+      value: value,
+      setter: setter,
+      instanceRefId: instanceRefId,
+    );
+  }
+}
+
+/// @nodoc
+// ignore: unused_element
+const $InstanceDetails = _$InstanceDetailsTearOff();
+
+/// @nodoc
+mixin _$InstanceDetails {
+  String get instanceRefId;
+  @nullable
+  Future<void> Function(String) get setter;
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object>({
+    @required
+        TResult nill(String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult boolean(String displayString, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult number(String displayString, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult string(String displayString, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult map(List<InstanceDetails> keys, int hash, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult list(@nullable int length, int hash, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult object(
+            List<ObjectField> fields,
+            String type,
+            int hash,
+            String instanceRefId,
+            @nullable Future<void> Function(String) setter,
+            EvalOnDartLibrary evalForInstance),
+    @required
+        TResult enumeration(
+            String type,
+            String value,
+            @nullable Future<void> Function(String) setter,
+            String instanceRefId),
+  });
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object>({
+    TResult nill(
+        String instanceRefId, @nullable Future<void> Function(String) setter),
+    TResult boolean(String displayString, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult number(String displayString, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult string(String displayString, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult map(List<InstanceDetails> keys, int hash, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult list(@nullable int length, int hash, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult object(
+        List<ObjectField> fields,
+        String type,
+        int hash,
+        String instanceRefId,
+        @nullable Future<void> Function(String) setter,
+        EvalOnDartLibrary evalForInstance),
+    TResult enumeration(String type, String value,
+        @nullable Future<void> Function(String) setter, String instanceRefId),
+    @required TResult orElse(),
+  });
+  @optionalTypeArgs
+  TResult map<TResult extends Object>({
+    @required TResult nill(NullInstance value),
+    @required TResult boolean(BoolInstance value),
+    @required TResult number(NumInstance value),
+    @required TResult string(StringInstance value),
+    @required TResult map(MapInstance value),
+    @required TResult list(ListInstance value),
+    @required TResult object(ObjectInstance value),
+    @required TResult enumeration(EnumInstance value),
+  });
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object>({
+    TResult nill(NullInstance value),
+    TResult boolean(BoolInstance value),
+    TResult number(NumInstance value),
+    TResult string(StringInstance value),
+    TResult map(MapInstance value),
+    TResult list(ListInstance value),
+    TResult object(ObjectInstance value),
+    TResult enumeration(EnumInstance value),
+    @required TResult orElse(),
+  });
+
+  @JsonKey(ignore: true)
+  $InstanceDetailsCopyWith<InstanceDetails> get copyWith;
+}
+
+/// @nodoc
+abstract class $InstanceDetailsCopyWith<$Res> {
+  factory $InstanceDetailsCopyWith(
+          InstanceDetails value, $Res Function(InstanceDetails) then) =
+      _$InstanceDetailsCopyWithImpl<$Res>;
+  $Res call(
+      {String instanceRefId, @nullable Future<void> Function(String) setter});
+}
+
+/// @nodoc
+class _$InstanceDetailsCopyWithImpl<$Res>
+    implements $InstanceDetailsCopyWith<$Res> {
+  _$InstanceDetailsCopyWithImpl(this._value, this._then);
+
+  final InstanceDetails _value;
+  // ignore: unused_field
+  final $Res Function(InstanceDetails) _then;
+
+  @override
+  $Res call({
+    Object instanceRefId = freezed,
+    Object setter = freezed,
+  }) {
+    return _then(_value.copyWith(
+      instanceRefId: instanceRefId == freezed
+          ? _value.instanceRefId
+          : instanceRefId as String,
+      setter: setter == freezed
+          ? _value.setter
+          : setter as Future<void> Function(String),
+    ));
+  }
+}
+
+/// @nodoc
+abstract class $NullInstanceCopyWith<$Res>
+    implements $InstanceDetailsCopyWith<$Res> {
+  factory $NullInstanceCopyWith(
+          NullInstance value, $Res Function(NullInstance) then) =
+      _$NullInstanceCopyWithImpl<$Res>;
+  @override
+  $Res call(
+      {String instanceRefId, @nullable Future<void> Function(String) setter});
+}
+
+/// @nodoc
+class _$NullInstanceCopyWithImpl<$Res>
+    extends _$InstanceDetailsCopyWithImpl<$Res>
+    implements $NullInstanceCopyWith<$Res> {
+  _$NullInstanceCopyWithImpl(
+      NullInstance _value, $Res Function(NullInstance) _then)
+      : super(_value, (v) => _then(v as NullInstance));
+
+  @override
+  NullInstance get _value => super._value as NullInstance;
+
+  @override
+  $Res call({
+    Object instanceRefId = freezed,
+    Object setter = freezed,
+  }) {
+    return _then(NullInstance(
+      instanceRefId: instanceRefId == freezed
+          ? _value.instanceRefId
+          : instanceRefId as String,
+      setter: setter == freezed
+          ? _value.setter
+          : setter as Future<void> Function(String),
+    ));
+  }
+}
+
+/// @nodoc
+class _$NullInstance extends NullInstance {
+  _$NullInstance({this.instanceRefId, @required @nullable this.setter})
+      : assert(instanceRefId == null),
+        super._();
+
+  @override
+  final String instanceRefId;
+  @override
+  @nullable
+  final Future<void> Function(String) setter;
+
+  @override
+  String toString() {
+    return 'InstanceDetails.nill(instanceRefId: $instanceRefId, setter: $setter)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other is NullInstance &&
+            (identical(other.instanceRefId, instanceRefId) ||
+                const DeepCollectionEquality()
+                    .equals(other.instanceRefId, instanceRefId)) &&
+            (identical(other.setter, setter) ||
+                const DeepCollectionEquality().equals(other.setter, setter)));
+  }
+
+  @override
+  int get hashCode =>
+      runtimeType.hashCode ^
+      const DeepCollectionEquality().hash(instanceRefId) ^
+      const DeepCollectionEquality().hash(setter);
+
+  @JsonKey(ignore: true)
+  @override
+  $NullInstanceCopyWith<NullInstance> get copyWith =>
+      _$NullInstanceCopyWithImpl<NullInstance>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object>({
+    @required
+        TResult nill(String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult boolean(String displayString, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult number(String displayString, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult string(String displayString, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult map(List<InstanceDetails> keys, int hash, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult list(@nullable int length, int hash, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult object(
+            List<ObjectField> fields,
+            String type,
+            int hash,
+            String instanceRefId,
+            @nullable Future<void> Function(String) setter,
+            EvalOnDartLibrary evalForInstance),
+    @required
+        TResult enumeration(
+            String type,
+            String value,
+            @nullable Future<void> Function(String) setter,
+            String instanceRefId),
+  }) {
+    assert(nill != null);
+    assert(boolean != null);
+    assert(number != null);
+    assert(string != null);
+    assert(map != null);
+    assert(list != null);
+    assert(object != null);
+    assert(enumeration != null);
+    return nill(instanceRefId, setter);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object>({
+    TResult nill(
+        String instanceRefId, @nullable Future<void> Function(String) setter),
+    TResult boolean(String displayString, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult number(String displayString, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult string(String displayString, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult map(List<InstanceDetails> keys, int hash, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult list(@nullable int length, int hash, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult object(
+        List<ObjectField> fields,
+        String type,
+        int hash,
+        String instanceRefId,
+        @nullable Future<void> Function(String) setter,
+        EvalOnDartLibrary evalForInstance),
+    TResult enumeration(String type, String value,
+        @nullable Future<void> Function(String) setter, String instanceRefId),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (nill != null) {
+      return nill(instanceRefId, setter);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object>({
+    @required TResult nill(NullInstance value),
+    @required TResult boolean(BoolInstance value),
+    @required TResult number(NumInstance value),
+    @required TResult string(StringInstance value),
+    @required TResult map(MapInstance value),
+    @required TResult list(ListInstance value),
+    @required TResult object(ObjectInstance value),
+    @required TResult enumeration(EnumInstance value),
+  }) {
+    assert(nill != null);
+    assert(boolean != null);
+    assert(number != null);
+    assert(string != null);
+    assert(map != null);
+    assert(list != null);
+    assert(object != null);
+    assert(enumeration != null);
+    return nill(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object>({
+    TResult nill(NullInstance value),
+    TResult boolean(BoolInstance value),
+    TResult number(NumInstance value),
+    TResult string(StringInstance value),
+    TResult map(MapInstance value),
+    TResult list(ListInstance value),
+    TResult object(ObjectInstance value),
+    TResult enumeration(EnumInstance value),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (nill != null) {
+      return nill(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class NullInstance extends InstanceDetails {
+  NullInstance._() : super._();
+  factory NullInstance(
+          {String instanceRefId,
+          @required @nullable Future<void> Function(String) setter}) =
+      _$NullInstance;
+
+  @override
+  String get instanceRefId;
+  @override
+  @nullable
+  Future<void> Function(String) get setter;
+  @override
+  @JsonKey(ignore: true)
+  $NullInstanceCopyWith<NullInstance> get copyWith;
+}
+
+/// @nodoc
+abstract class $BoolInstanceCopyWith<$Res>
+    implements $InstanceDetailsCopyWith<$Res> {
+  factory $BoolInstanceCopyWith(
+          BoolInstance value, $Res Function(BoolInstance) then) =
+      _$BoolInstanceCopyWithImpl<$Res>;
+  @override
+  $Res call(
+      {String displayString,
+      String instanceRefId,
+      @nullable Future<void> Function(String) setter});
+}
+
+/// @nodoc
+class _$BoolInstanceCopyWithImpl<$Res>
+    extends _$InstanceDetailsCopyWithImpl<$Res>
+    implements $BoolInstanceCopyWith<$Res> {
+  _$BoolInstanceCopyWithImpl(
+      BoolInstance _value, $Res Function(BoolInstance) _then)
+      : super(_value, (v) => _then(v as BoolInstance));
+
+  @override
+  BoolInstance get _value => super._value as BoolInstance;
+
+  @override
+  $Res call({
+    Object displayString = freezed,
+    Object instanceRefId = freezed,
+    Object setter = freezed,
+  }) {
+    return _then(BoolInstance(
+      displayString == freezed ? _value.displayString : displayString as String,
+      instanceRefId: instanceRefId == freezed
+          ? _value.instanceRefId
+          : instanceRefId as String,
+      setter: setter == freezed
+          ? _value.setter
+          : setter as Future<void> Function(String),
+    ));
+  }
+}
+
+/// @nodoc
+class _$BoolInstance extends BoolInstance {
+  _$BoolInstance(this.displayString,
+      {@required this.instanceRefId, @required @nullable this.setter})
+      : assert(displayString != null),
+        assert(instanceRefId != null),
+        super._();
+
+  @override
+  final String displayString;
+  @override
+  final String instanceRefId;
+  @override
+  @nullable
+  final Future<void> Function(String) setter;
+
+  @override
+  String toString() {
+    return 'InstanceDetails.boolean(displayString: $displayString, instanceRefId: $instanceRefId, setter: $setter)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other is BoolInstance &&
+            (identical(other.displayString, displayString) ||
+                const DeepCollectionEquality()
+                    .equals(other.displayString, displayString)) &&
+            (identical(other.instanceRefId, instanceRefId) ||
+                const DeepCollectionEquality()
+                    .equals(other.instanceRefId, instanceRefId)) &&
+            (identical(other.setter, setter) ||
+                const DeepCollectionEquality().equals(other.setter, setter)));
+  }
+
+  @override
+  int get hashCode =>
+      runtimeType.hashCode ^
+      const DeepCollectionEquality().hash(displayString) ^
+      const DeepCollectionEquality().hash(instanceRefId) ^
+      const DeepCollectionEquality().hash(setter);
+
+  @JsonKey(ignore: true)
+  @override
+  $BoolInstanceCopyWith<BoolInstance> get copyWith =>
+      _$BoolInstanceCopyWithImpl<BoolInstance>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object>({
+    @required
+        TResult nill(String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult boolean(String displayString, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult number(String displayString, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult string(String displayString, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult map(List<InstanceDetails> keys, int hash, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult list(@nullable int length, int hash, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult object(
+            List<ObjectField> fields,
+            String type,
+            int hash,
+            String instanceRefId,
+            @nullable Future<void> Function(String) setter,
+            EvalOnDartLibrary evalForInstance),
+    @required
+        TResult enumeration(
+            String type,
+            String value,
+            @nullable Future<void> Function(String) setter,
+            String instanceRefId),
+  }) {
+    assert(nill != null);
+    assert(boolean != null);
+    assert(number != null);
+    assert(string != null);
+    assert(map != null);
+    assert(list != null);
+    assert(object != null);
+    assert(enumeration != null);
+    return boolean(displayString, instanceRefId, setter);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object>({
+    TResult nill(
+        String instanceRefId, @nullable Future<void> Function(String) setter),
+    TResult boolean(String displayString, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult number(String displayString, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult string(String displayString, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult map(List<InstanceDetails> keys, int hash, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult list(@nullable int length, int hash, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult object(
+        List<ObjectField> fields,
+        String type,
+        int hash,
+        String instanceRefId,
+        @nullable Future<void> Function(String) setter,
+        EvalOnDartLibrary evalForInstance),
+    TResult enumeration(String type, String value,
+        @nullable Future<void> Function(String) setter, String instanceRefId),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (boolean != null) {
+      return boolean(displayString, instanceRefId, setter);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object>({
+    @required TResult nill(NullInstance value),
+    @required TResult boolean(BoolInstance value),
+    @required TResult number(NumInstance value),
+    @required TResult string(StringInstance value),
+    @required TResult map(MapInstance value),
+    @required TResult list(ListInstance value),
+    @required TResult object(ObjectInstance value),
+    @required TResult enumeration(EnumInstance value),
+  }) {
+    assert(nill != null);
+    assert(boolean != null);
+    assert(number != null);
+    assert(string != null);
+    assert(map != null);
+    assert(list != null);
+    assert(object != null);
+    assert(enumeration != null);
+    return boolean(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object>({
+    TResult nill(NullInstance value),
+    TResult boolean(BoolInstance value),
+    TResult number(NumInstance value),
+    TResult string(StringInstance value),
+    TResult map(MapInstance value),
+    TResult list(ListInstance value),
+    TResult object(ObjectInstance value),
+    TResult enumeration(EnumInstance value),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (boolean != null) {
+      return boolean(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class BoolInstance extends InstanceDetails {
+  BoolInstance._() : super._();
+  factory BoolInstance(String displayString,
+          {@required String instanceRefId,
+          @required @nullable Future<void> Function(String) setter}) =
+      _$BoolInstance;
+
+  String get displayString;
+  @override
+  String get instanceRefId;
+  @override
+  @nullable
+  Future<void> Function(String) get setter;
+  @override
+  @JsonKey(ignore: true)
+  $BoolInstanceCopyWith<BoolInstance> get copyWith;
+}
+
+/// @nodoc
+abstract class $NumInstanceCopyWith<$Res>
+    implements $InstanceDetailsCopyWith<$Res> {
+  factory $NumInstanceCopyWith(
+          NumInstance value, $Res Function(NumInstance) then) =
+      _$NumInstanceCopyWithImpl<$Res>;
+  @override
+  $Res call(
+      {String displayString,
+      String instanceRefId,
+      @nullable Future<void> Function(String) setter});
+}
+
+/// @nodoc
+class _$NumInstanceCopyWithImpl<$Res>
+    extends _$InstanceDetailsCopyWithImpl<$Res>
+    implements $NumInstanceCopyWith<$Res> {
+  _$NumInstanceCopyWithImpl(
+      NumInstance _value, $Res Function(NumInstance) _then)
+      : super(_value, (v) => _then(v as NumInstance));
+
+  @override
+  NumInstance get _value => super._value as NumInstance;
+
+  @override
+  $Res call({
+    Object displayString = freezed,
+    Object instanceRefId = freezed,
+    Object setter = freezed,
+  }) {
+    return _then(NumInstance(
+      displayString == freezed ? _value.displayString : displayString as String,
+      instanceRefId: instanceRefId == freezed
+          ? _value.instanceRefId
+          : instanceRefId as String,
+      setter: setter == freezed
+          ? _value.setter
+          : setter as Future<void> Function(String),
+    ));
+  }
+}
+
+/// @nodoc
+class _$NumInstance extends NumInstance {
+  _$NumInstance(this.displayString,
+      {@required this.instanceRefId, @required @nullable this.setter})
+      : assert(displayString != null),
+        assert(instanceRefId != null),
+        super._();
+
+  @override
+  final String displayString;
+  @override
+  final String instanceRefId;
+  @override
+  @nullable
+  final Future<void> Function(String) setter;
+
+  @override
+  String toString() {
+    return 'InstanceDetails.number(displayString: $displayString, instanceRefId: $instanceRefId, setter: $setter)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other is NumInstance &&
+            (identical(other.displayString, displayString) ||
+                const DeepCollectionEquality()
+                    .equals(other.displayString, displayString)) &&
+            (identical(other.instanceRefId, instanceRefId) ||
+                const DeepCollectionEquality()
+                    .equals(other.instanceRefId, instanceRefId)) &&
+            (identical(other.setter, setter) ||
+                const DeepCollectionEquality().equals(other.setter, setter)));
+  }
+
+  @override
+  int get hashCode =>
+      runtimeType.hashCode ^
+      const DeepCollectionEquality().hash(displayString) ^
+      const DeepCollectionEquality().hash(instanceRefId) ^
+      const DeepCollectionEquality().hash(setter);
+
+  @JsonKey(ignore: true)
+  @override
+  $NumInstanceCopyWith<NumInstance> get copyWith =>
+      _$NumInstanceCopyWithImpl<NumInstance>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object>({
+    @required
+        TResult nill(String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult boolean(String displayString, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult number(String displayString, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult string(String displayString, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult map(List<InstanceDetails> keys, int hash, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult list(@nullable int length, int hash, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult object(
+            List<ObjectField> fields,
+            String type,
+            int hash,
+            String instanceRefId,
+            @nullable Future<void> Function(String) setter,
+            EvalOnDartLibrary evalForInstance),
+    @required
+        TResult enumeration(
+            String type,
+            String value,
+            @nullable Future<void> Function(String) setter,
+            String instanceRefId),
+  }) {
+    assert(nill != null);
+    assert(boolean != null);
+    assert(number != null);
+    assert(string != null);
+    assert(map != null);
+    assert(list != null);
+    assert(object != null);
+    assert(enumeration != null);
+    return number(displayString, instanceRefId, setter);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object>({
+    TResult nill(
+        String instanceRefId, @nullable Future<void> Function(String) setter),
+    TResult boolean(String displayString, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult number(String displayString, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult string(String displayString, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult map(List<InstanceDetails> keys, int hash, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult list(@nullable int length, int hash, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult object(
+        List<ObjectField> fields,
+        String type,
+        int hash,
+        String instanceRefId,
+        @nullable Future<void> Function(String) setter,
+        EvalOnDartLibrary evalForInstance),
+    TResult enumeration(String type, String value,
+        @nullable Future<void> Function(String) setter, String instanceRefId),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (number != null) {
+      return number(displayString, instanceRefId, setter);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object>({
+    @required TResult nill(NullInstance value),
+    @required TResult boolean(BoolInstance value),
+    @required TResult number(NumInstance value),
+    @required TResult string(StringInstance value),
+    @required TResult map(MapInstance value),
+    @required TResult list(ListInstance value),
+    @required TResult object(ObjectInstance value),
+    @required TResult enumeration(EnumInstance value),
+  }) {
+    assert(nill != null);
+    assert(boolean != null);
+    assert(number != null);
+    assert(string != null);
+    assert(map != null);
+    assert(list != null);
+    assert(object != null);
+    assert(enumeration != null);
+    return number(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object>({
+    TResult nill(NullInstance value),
+    TResult boolean(BoolInstance value),
+    TResult number(NumInstance value),
+    TResult string(StringInstance value),
+    TResult map(MapInstance value),
+    TResult list(ListInstance value),
+    TResult object(ObjectInstance value),
+    TResult enumeration(EnumInstance value),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (number != null) {
+      return number(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class NumInstance extends InstanceDetails {
+  NumInstance._() : super._();
+  factory NumInstance(String displayString,
+          {@required String instanceRefId,
+          @required @nullable Future<void> Function(String) setter}) =
+      _$NumInstance;
+
+  String get displayString;
+  @override
+  String get instanceRefId;
+  @override
+  @nullable
+  Future<void> Function(String) get setter;
+  @override
+  @JsonKey(ignore: true)
+  $NumInstanceCopyWith<NumInstance> get copyWith;
+}
+
+/// @nodoc
+abstract class $StringInstanceCopyWith<$Res>
+    implements $InstanceDetailsCopyWith<$Res> {
+  factory $StringInstanceCopyWith(
+          StringInstance value, $Res Function(StringInstance) then) =
+      _$StringInstanceCopyWithImpl<$Res>;
+  @override
+  $Res call(
+      {String displayString,
+      String instanceRefId,
+      @nullable Future<void> Function(String) setter});
+}
+
+/// @nodoc
+class _$StringInstanceCopyWithImpl<$Res>
+    extends _$InstanceDetailsCopyWithImpl<$Res>
+    implements $StringInstanceCopyWith<$Res> {
+  _$StringInstanceCopyWithImpl(
+      StringInstance _value, $Res Function(StringInstance) _then)
+      : super(_value, (v) => _then(v as StringInstance));
+
+  @override
+  StringInstance get _value => super._value as StringInstance;
+
+  @override
+  $Res call({
+    Object displayString = freezed,
+    Object instanceRefId = freezed,
+    Object setter = freezed,
+  }) {
+    return _then(StringInstance(
+      displayString == freezed ? _value.displayString : displayString as String,
+      instanceRefId: instanceRefId == freezed
+          ? _value.instanceRefId
+          : instanceRefId as String,
+      setter: setter == freezed
+          ? _value.setter
+          : setter as Future<void> Function(String),
+    ));
+  }
+}
+
+/// @nodoc
+class _$StringInstance extends StringInstance {
+  _$StringInstance(this.displayString,
+      {@required this.instanceRefId, @required @nullable this.setter})
+      : assert(displayString != null),
+        assert(instanceRefId != null),
+        super._();
+
+  @override
+  final String displayString;
+  @override
+  final String instanceRefId;
+  @override
+  @nullable
+  final Future<void> Function(String) setter;
+
+  @override
+  String toString() {
+    return 'InstanceDetails.string(displayString: $displayString, instanceRefId: $instanceRefId, setter: $setter)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other is StringInstance &&
+            (identical(other.displayString, displayString) ||
+                const DeepCollectionEquality()
+                    .equals(other.displayString, displayString)) &&
+            (identical(other.instanceRefId, instanceRefId) ||
+                const DeepCollectionEquality()
+                    .equals(other.instanceRefId, instanceRefId)) &&
+            (identical(other.setter, setter) ||
+                const DeepCollectionEquality().equals(other.setter, setter)));
+  }
+
+  @override
+  int get hashCode =>
+      runtimeType.hashCode ^
+      const DeepCollectionEquality().hash(displayString) ^
+      const DeepCollectionEquality().hash(instanceRefId) ^
+      const DeepCollectionEquality().hash(setter);
+
+  @JsonKey(ignore: true)
+  @override
+  $StringInstanceCopyWith<StringInstance> get copyWith =>
+      _$StringInstanceCopyWithImpl<StringInstance>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object>({
+    @required
+        TResult nill(String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult boolean(String displayString, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult number(String displayString, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult string(String displayString, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult map(List<InstanceDetails> keys, int hash, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult list(@nullable int length, int hash, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult object(
+            List<ObjectField> fields,
+            String type,
+            int hash,
+            String instanceRefId,
+            @nullable Future<void> Function(String) setter,
+            EvalOnDartLibrary evalForInstance),
+    @required
+        TResult enumeration(
+            String type,
+            String value,
+            @nullable Future<void> Function(String) setter,
+            String instanceRefId),
+  }) {
+    assert(nill != null);
+    assert(boolean != null);
+    assert(number != null);
+    assert(string != null);
+    assert(map != null);
+    assert(list != null);
+    assert(object != null);
+    assert(enumeration != null);
+    return string(displayString, instanceRefId, setter);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object>({
+    TResult nill(
+        String instanceRefId, @nullable Future<void> Function(String) setter),
+    TResult boolean(String displayString, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult number(String displayString, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult string(String displayString, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult map(List<InstanceDetails> keys, int hash, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult list(@nullable int length, int hash, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult object(
+        List<ObjectField> fields,
+        String type,
+        int hash,
+        String instanceRefId,
+        @nullable Future<void> Function(String) setter,
+        EvalOnDartLibrary evalForInstance),
+    TResult enumeration(String type, String value,
+        @nullable Future<void> Function(String) setter, String instanceRefId),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (string != null) {
+      return string(displayString, instanceRefId, setter);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object>({
+    @required TResult nill(NullInstance value),
+    @required TResult boolean(BoolInstance value),
+    @required TResult number(NumInstance value),
+    @required TResult string(StringInstance value),
+    @required TResult map(MapInstance value),
+    @required TResult list(ListInstance value),
+    @required TResult object(ObjectInstance value),
+    @required TResult enumeration(EnumInstance value),
+  }) {
+    assert(nill != null);
+    assert(boolean != null);
+    assert(number != null);
+    assert(string != null);
+    assert(map != null);
+    assert(list != null);
+    assert(object != null);
+    assert(enumeration != null);
+    return string(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object>({
+    TResult nill(NullInstance value),
+    TResult boolean(BoolInstance value),
+    TResult number(NumInstance value),
+    TResult string(StringInstance value),
+    TResult map(MapInstance value),
+    TResult list(ListInstance value),
+    TResult object(ObjectInstance value),
+    TResult enumeration(EnumInstance value),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (string != null) {
+      return string(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class StringInstance extends InstanceDetails {
+  StringInstance._() : super._();
+  factory StringInstance(String displayString,
+          {@required String instanceRefId,
+          @required @nullable Future<void> Function(String) setter}) =
+      _$StringInstance;
+
+  String get displayString;
+  @override
+  String get instanceRefId;
+  @override
+  @nullable
+  Future<void> Function(String) get setter;
+  @override
+  @JsonKey(ignore: true)
+  $StringInstanceCopyWith<StringInstance> get copyWith;
+}
+
+/// @nodoc
+abstract class $MapInstanceCopyWith<$Res>
+    implements $InstanceDetailsCopyWith<$Res> {
+  factory $MapInstanceCopyWith(
+          MapInstance value, $Res Function(MapInstance) then) =
+      _$MapInstanceCopyWithImpl<$Res>;
+  @override
+  $Res call(
+      {List<InstanceDetails> keys,
+      int hash,
+      String instanceRefId,
+      @nullable Future<void> Function(String) setter});
+}
+
+/// @nodoc
+class _$MapInstanceCopyWithImpl<$Res>
+    extends _$InstanceDetailsCopyWithImpl<$Res>
+    implements $MapInstanceCopyWith<$Res> {
+  _$MapInstanceCopyWithImpl(
+      MapInstance _value, $Res Function(MapInstance) _then)
+      : super(_value, (v) => _then(v as MapInstance));
+
+  @override
+  MapInstance get _value => super._value as MapInstance;
+
+  @override
+  $Res call({
+    Object keys = freezed,
+    Object hash = freezed,
+    Object instanceRefId = freezed,
+    Object setter = freezed,
+  }) {
+    return _then(MapInstance(
+      keys == freezed ? _value.keys : keys as List<InstanceDetails>,
+      hash: hash == freezed ? _value.hash : hash as int,
+      instanceRefId: instanceRefId == freezed
+          ? _value.instanceRefId
+          : instanceRefId as String,
+      setter: setter == freezed
+          ? _value.setter
+          : setter as Future<void> Function(String),
+    ));
+  }
+}
+
+/// @nodoc
+class _$MapInstance extends MapInstance {
+  _$MapInstance(this.keys,
+      {@required this.hash,
+      @required this.instanceRefId,
+      @required @nullable this.setter})
+      : assert(keys != null),
+        assert(hash != null),
+        assert(instanceRefId != null),
+        super._();
+
+  @override
+  final List<InstanceDetails> keys;
+  @override
+  final int hash;
+  @override
+  final String instanceRefId;
+  @override
+  @nullable
+  final Future<void> Function(String) setter;
+
+  @override
+  String toString() {
+    return 'InstanceDetails.map(keys: $keys, hash: $hash, instanceRefId: $instanceRefId, setter: $setter)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other is MapInstance &&
+            (identical(other.keys, keys) ||
+                const DeepCollectionEquality().equals(other.keys, keys)) &&
+            (identical(other.hash, hash) ||
+                const DeepCollectionEquality().equals(other.hash, hash)) &&
+            (identical(other.instanceRefId, instanceRefId) ||
+                const DeepCollectionEquality()
+                    .equals(other.instanceRefId, instanceRefId)) &&
+            (identical(other.setter, setter) ||
+                const DeepCollectionEquality().equals(other.setter, setter)));
+  }
+
+  @override
+  int get hashCode =>
+      runtimeType.hashCode ^
+      const DeepCollectionEquality().hash(keys) ^
+      const DeepCollectionEquality().hash(hash) ^
+      const DeepCollectionEquality().hash(instanceRefId) ^
+      const DeepCollectionEquality().hash(setter);
+
+  @JsonKey(ignore: true)
+  @override
+  $MapInstanceCopyWith<MapInstance> get copyWith =>
+      _$MapInstanceCopyWithImpl<MapInstance>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object>({
+    @required
+        TResult nill(String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult boolean(String displayString, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult number(String displayString, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult string(String displayString, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult map(List<InstanceDetails> keys, int hash, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult list(@nullable int length, int hash, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult object(
+            List<ObjectField> fields,
+            String type,
+            int hash,
+            String instanceRefId,
+            @nullable Future<void> Function(String) setter,
+            EvalOnDartLibrary evalForInstance),
+    @required
+        TResult enumeration(
+            String type,
+            String value,
+            @nullable Future<void> Function(String) setter,
+            String instanceRefId),
+  }) {
+    assert(nill != null);
+    assert(boolean != null);
+    assert(number != null);
+    assert(string != null);
+    assert(map != null);
+    assert(list != null);
+    assert(object != null);
+    assert(enumeration != null);
+    return map(keys, hash, instanceRefId, setter);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object>({
+    TResult nill(
+        String instanceRefId, @nullable Future<void> Function(String) setter),
+    TResult boolean(String displayString, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult number(String displayString, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult string(String displayString, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult map(List<InstanceDetails> keys, int hash, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult list(@nullable int length, int hash, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult object(
+        List<ObjectField> fields,
+        String type,
+        int hash,
+        String instanceRefId,
+        @nullable Future<void> Function(String) setter,
+        EvalOnDartLibrary evalForInstance),
+    TResult enumeration(String type, String value,
+        @nullable Future<void> Function(String) setter, String instanceRefId),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (map != null) {
+      return map(keys, hash, instanceRefId, setter);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object>({
+    @required TResult nill(NullInstance value),
+    @required TResult boolean(BoolInstance value),
+    @required TResult number(NumInstance value),
+    @required TResult string(StringInstance value),
+    @required TResult map(MapInstance value),
+    @required TResult list(ListInstance value),
+    @required TResult object(ObjectInstance value),
+    @required TResult enumeration(EnumInstance value),
+  }) {
+    assert(nill != null);
+    assert(boolean != null);
+    assert(number != null);
+    assert(string != null);
+    assert(map != null);
+    assert(list != null);
+    assert(object != null);
+    assert(enumeration != null);
+    return map(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object>({
+    TResult nill(NullInstance value),
+    TResult boolean(BoolInstance value),
+    TResult number(NumInstance value),
+    TResult string(StringInstance value),
+    TResult map(MapInstance value),
+    TResult list(ListInstance value),
+    TResult object(ObjectInstance value),
+    TResult enumeration(EnumInstance value),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (map != null) {
+      return map(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class MapInstance extends InstanceDetails {
+  MapInstance._() : super._();
+  factory MapInstance(List<InstanceDetails> keys,
+          {@required int hash,
+          @required String instanceRefId,
+          @required @nullable Future<void> Function(String) setter}) =
+      _$MapInstance;
+
+  List<InstanceDetails> get keys;
+  int get hash;
+  @override
+  String get instanceRefId;
+  @override
+  @nullable
+  Future<void> Function(String) get setter;
+  @override
+  @JsonKey(ignore: true)
+  $MapInstanceCopyWith<MapInstance> get copyWith;
+}
+
+/// @nodoc
+abstract class $ListInstanceCopyWith<$Res>
+    implements $InstanceDetailsCopyWith<$Res> {
+  factory $ListInstanceCopyWith(
+          ListInstance value, $Res Function(ListInstance) then) =
+      _$ListInstanceCopyWithImpl<$Res>;
+  @override
+  $Res call(
+      {@nullable int length,
+      int hash,
+      String instanceRefId,
+      @nullable Future<void> Function(String) setter});
+}
+
+/// @nodoc
+class _$ListInstanceCopyWithImpl<$Res>
+    extends _$InstanceDetailsCopyWithImpl<$Res>
+    implements $ListInstanceCopyWith<$Res> {
+  _$ListInstanceCopyWithImpl(
+      ListInstance _value, $Res Function(ListInstance) _then)
+      : super(_value, (v) => _then(v as ListInstance));
+
+  @override
+  ListInstance get _value => super._value as ListInstance;
+
+  @override
+  $Res call({
+    Object length = freezed,
+    Object hash = freezed,
+    Object instanceRefId = freezed,
+    Object setter = freezed,
+  }) {
+    return _then(ListInstance(
+      length: length == freezed ? _value.length : length as int,
+      hash: hash == freezed ? _value.hash : hash as int,
+      instanceRefId: instanceRefId == freezed
+          ? _value.instanceRefId
+          : instanceRefId as String,
+      setter: setter == freezed
+          ? _value.setter
+          : setter as Future<void> Function(String),
+    ));
+  }
+}
+
+/// @nodoc
+class _$ListInstance extends ListInstance {
+  _$ListInstance(
+      {@required @nullable this.length,
+      @required this.hash,
+      @required this.instanceRefId,
+      @required @nullable this.setter})
+      : assert(hash != null),
+        assert(instanceRefId != null),
+        super._();
+
+  @override
+  @nullable
+  final int length;
+  @override
+  final int hash;
+  @override
+  final String instanceRefId;
+  @override
+  @nullable
+  final Future<void> Function(String) setter;
+
+  @override
+  String toString() {
+    return 'InstanceDetails.list(length: $length, hash: $hash, instanceRefId: $instanceRefId, setter: $setter)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other is ListInstance &&
+            (identical(other.length, length) ||
+                const DeepCollectionEquality().equals(other.length, length)) &&
+            (identical(other.hash, hash) ||
+                const DeepCollectionEquality().equals(other.hash, hash)) &&
+            (identical(other.instanceRefId, instanceRefId) ||
+                const DeepCollectionEquality()
+                    .equals(other.instanceRefId, instanceRefId)) &&
+            (identical(other.setter, setter) ||
+                const DeepCollectionEquality().equals(other.setter, setter)));
+  }
+
+  @override
+  int get hashCode =>
+      runtimeType.hashCode ^
+      const DeepCollectionEquality().hash(length) ^
+      const DeepCollectionEquality().hash(hash) ^
+      const DeepCollectionEquality().hash(instanceRefId) ^
+      const DeepCollectionEquality().hash(setter);
+
+  @JsonKey(ignore: true)
+  @override
+  $ListInstanceCopyWith<ListInstance> get copyWith =>
+      _$ListInstanceCopyWithImpl<ListInstance>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object>({
+    @required
+        TResult nill(String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult boolean(String displayString, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult number(String displayString, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult string(String displayString, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult map(List<InstanceDetails> keys, int hash, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult list(@nullable int length, int hash, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult object(
+            List<ObjectField> fields,
+            String type,
+            int hash,
+            String instanceRefId,
+            @nullable Future<void> Function(String) setter,
+            EvalOnDartLibrary evalForInstance),
+    @required
+        TResult enumeration(
+            String type,
+            String value,
+            @nullable Future<void> Function(String) setter,
+            String instanceRefId),
+  }) {
+    assert(nill != null);
+    assert(boolean != null);
+    assert(number != null);
+    assert(string != null);
+    assert(map != null);
+    assert(list != null);
+    assert(object != null);
+    assert(enumeration != null);
+    return list(length, hash, instanceRefId, setter);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object>({
+    TResult nill(
+        String instanceRefId, @nullable Future<void> Function(String) setter),
+    TResult boolean(String displayString, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult number(String displayString, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult string(String displayString, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult map(List<InstanceDetails> keys, int hash, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult list(@nullable int length, int hash, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult object(
+        List<ObjectField> fields,
+        String type,
+        int hash,
+        String instanceRefId,
+        @nullable Future<void> Function(String) setter,
+        EvalOnDartLibrary evalForInstance),
+    TResult enumeration(String type, String value,
+        @nullable Future<void> Function(String) setter, String instanceRefId),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (list != null) {
+      return list(length, hash, instanceRefId, setter);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object>({
+    @required TResult nill(NullInstance value),
+    @required TResult boolean(BoolInstance value),
+    @required TResult number(NumInstance value),
+    @required TResult string(StringInstance value),
+    @required TResult map(MapInstance value),
+    @required TResult list(ListInstance value),
+    @required TResult object(ObjectInstance value),
+    @required TResult enumeration(EnumInstance value),
+  }) {
+    assert(nill != null);
+    assert(boolean != null);
+    assert(number != null);
+    assert(string != null);
+    assert(map != null);
+    assert(list != null);
+    assert(object != null);
+    assert(enumeration != null);
+    return list(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object>({
+    TResult nill(NullInstance value),
+    TResult boolean(BoolInstance value),
+    TResult number(NumInstance value),
+    TResult string(StringInstance value),
+    TResult map(MapInstance value),
+    TResult list(ListInstance value),
+    TResult object(ObjectInstance value),
+    TResult enumeration(EnumInstance value),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (list != null) {
+      return list(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class ListInstance extends InstanceDetails {
+  ListInstance._() : super._();
+  factory ListInstance(
+          {@required @nullable int length,
+          @required int hash,
+          @required String instanceRefId,
+          @required @nullable Future<void> Function(String) setter}) =
+      _$ListInstance;
+
+  @nullable
+  int get length;
+  int get hash;
+  @override
+  String get instanceRefId;
+  @override
+  @nullable
+  Future<void> Function(String) get setter;
+  @override
+  @JsonKey(ignore: true)
+  $ListInstanceCopyWith<ListInstance> get copyWith;
+}
+
+/// @nodoc
+abstract class $ObjectInstanceCopyWith<$Res>
+    implements $InstanceDetailsCopyWith<$Res> {
+  factory $ObjectInstanceCopyWith(
+          ObjectInstance value, $Res Function(ObjectInstance) then) =
+      _$ObjectInstanceCopyWithImpl<$Res>;
+  @override
+  $Res call(
+      {List<ObjectField> fields,
+      String type,
+      int hash,
+      String instanceRefId,
+      @nullable Future<void> Function(String) setter,
+      EvalOnDartLibrary evalForInstance});
+}
+
+/// @nodoc
+class _$ObjectInstanceCopyWithImpl<$Res>
+    extends _$InstanceDetailsCopyWithImpl<$Res>
+    implements $ObjectInstanceCopyWith<$Res> {
+  _$ObjectInstanceCopyWithImpl(
+      ObjectInstance _value, $Res Function(ObjectInstance) _then)
+      : super(_value, (v) => _then(v as ObjectInstance));
+
+  @override
+  ObjectInstance get _value => super._value as ObjectInstance;
+
+  @override
+  $Res call({
+    Object fields = freezed,
+    Object type = freezed,
+    Object hash = freezed,
+    Object instanceRefId = freezed,
+    Object setter = freezed,
+    Object evalForInstance = freezed,
+  }) {
+    return _then(ObjectInstance(
+      fields == freezed ? _value.fields : fields as List<ObjectField>,
+      type: type == freezed ? _value.type : type as String,
+      hash: hash == freezed ? _value.hash : hash as int,
+      instanceRefId: instanceRefId == freezed
+          ? _value.instanceRefId
+          : instanceRefId as String,
+      setter: setter == freezed
+          ? _value.setter
+          : setter as Future<void> Function(String),
+      evalForInstance: evalForInstance == freezed
+          ? _value.evalForInstance
+          : evalForInstance as EvalOnDartLibrary,
+    ));
+  }
+}
+
+/// @nodoc
+class _$ObjectInstance extends ObjectInstance {
+  _$ObjectInstance(this.fields,
+      {@required this.type,
+      @required this.hash,
+      @required this.instanceRefId,
+      @required @nullable this.setter,
+      @required this.evalForInstance})
+      : assert(fields != null),
+        assert(type != null),
+        assert(hash != null),
+        assert(instanceRefId != null),
+        assert(evalForInstance != null),
+        super._();
+
+  @override
+  final List<ObjectField> fields;
+  @override
+  final String type;
+  @override
+  final int hash;
+  @override
+  final String instanceRefId;
+  @override
+  @nullable
+  final Future<void> Function(String) setter;
+  @override
+
+  /// An [EvalOnDartLibrary] associated with the library of this object
+  ///
+  /// This allows to edit private properties.
+  final EvalOnDartLibrary evalForInstance;
+
+  @override
+  String toString() {
+    return 'InstanceDetails.object(fields: $fields, type: $type, hash: $hash, instanceRefId: $instanceRefId, setter: $setter, evalForInstance: $evalForInstance)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other is ObjectInstance &&
+            (identical(other.fields, fields) ||
+                const DeepCollectionEquality().equals(other.fields, fields)) &&
+            (identical(other.type, type) ||
+                const DeepCollectionEquality().equals(other.type, type)) &&
+            (identical(other.hash, hash) ||
+                const DeepCollectionEquality().equals(other.hash, hash)) &&
+            (identical(other.instanceRefId, instanceRefId) ||
+                const DeepCollectionEquality()
+                    .equals(other.instanceRefId, instanceRefId)) &&
+            (identical(other.setter, setter) ||
+                const DeepCollectionEquality().equals(other.setter, setter)) &&
+            (identical(other.evalForInstance, evalForInstance) ||
+                const DeepCollectionEquality()
+                    .equals(other.evalForInstance, evalForInstance)));
+  }
+
+  @override
+  int get hashCode =>
+      runtimeType.hashCode ^
+      const DeepCollectionEquality().hash(fields) ^
+      const DeepCollectionEquality().hash(type) ^
+      const DeepCollectionEquality().hash(hash) ^
+      const DeepCollectionEquality().hash(instanceRefId) ^
+      const DeepCollectionEquality().hash(setter) ^
+      const DeepCollectionEquality().hash(evalForInstance);
+
+  @JsonKey(ignore: true)
+  @override
+  $ObjectInstanceCopyWith<ObjectInstance> get copyWith =>
+      _$ObjectInstanceCopyWithImpl<ObjectInstance>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object>({
+    @required
+        TResult nill(String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult boolean(String displayString, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult number(String displayString, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult string(String displayString, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult map(List<InstanceDetails> keys, int hash, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult list(@nullable int length, int hash, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult object(
+            List<ObjectField> fields,
+            String type,
+            int hash,
+            String instanceRefId,
+            @nullable Future<void> Function(String) setter,
+            EvalOnDartLibrary evalForInstance),
+    @required
+        TResult enumeration(
+            String type,
+            String value,
+            @nullable Future<void> Function(String) setter,
+            String instanceRefId),
+  }) {
+    assert(nill != null);
+    assert(boolean != null);
+    assert(number != null);
+    assert(string != null);
+    assert(map != null);
+    assert(list != null);
+    assert(object != null);
+    assert(enumeration != null);
+    return object(fields, type, hash, instanceRefId, setter, evalForInstance);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object>({
+    TResult nill(
+        String instanceRefId, @nullable Future<void> Function(String) setter),
+    TResult boolean(String displayString, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult number(String displayString, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult string(String displayString, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult map(List<InstanceDetails> keys, int hash, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult list(@nullable int length, int hash, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult object(
+        List<ObjectField> fields,
+        String type,
+        int hash,
+        String instanceRefId,
+        @nullable Future<void> Function(String) setter,
+        EvalOnDartLibrary evalForInstance),
+    TResult enumeration(String type, String value,
+        @nullable Future<void> Function(String) setter, String instanceRefId),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (object != null) {
+      return object(fields, type, hash, instanceRefId, setter, evalForInstance);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object>({
+    @required TResult nill(NullInstance value),
+    @required TResult boolean(BoolInstance value),
+    @required TResult number(NumInstance value),
+    @required TResult string(StringInstance value),
+    @required TResult map(MapInstance value),
+    @required TResult list(ListInstance value),
+    @required TResult object(ObjectInstance value),
+    @required TResult enumeration(EnumInstance value),
+  }) {
+    assert(nill != null);
+    assert(boolean != null);
+    assert(number != null);
+    assert(string != null);
+    assert(map != null);
+    assert(list != null);
+    assert(object != null);
+    assert(enumeration != null);
+    return object(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object>({
+    TResult nill(NullInstance value),
+    TResult boolean(BoolInstance value),
+    TResult number(NumInstance value),
+    TResult string(StringInstance value),
+    TResult map(MapInstance value),
+    TResult list(ListInstance value),
+    TResult object(ObjectInstance value),
+    TResult enumeration(EnumInstance value),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (object != null) {
+      return object(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class ObjectInstance extends InstanceDetails {
+  ObjectInstance._() : super._();
+  factory ObjectInstance(List<ObjectField> fields,
+      {@required String type,
+      @required int hash,
+      @required String instanceRefId,
+      @required @nullable Future<void> Function(String) setter,
+      @required EvalOnDartLibrary evalForInstance}) = _$ObjectInstance;
+
+  List<ObjectField> get fields;
+  String get type;
+  int get hash;
+  @override
+  String get instanceRefId;
+  @override
+  @nullable
+  Future<void> Function(String) get setter;
+
+  /// An [EvalOnDartLibrary] associated with the library of this object
+  ///
+  /// This allows to edit private properties.
+  EvalOnDartLibrary get evalForInstance;
+  @override
+  @JsonKey(ignore: true)
+  $ObjectInstanceCopyWith<ObjectInstance> get copyWith;
+}
+
+/// @nodoc
+abstract class $EnumInstanceCopyWith<$Res>
+    implements $InstanceDetailsCopyWith<$Res> {
+  factory $EnumInstanceCopyWith(
+          EnumInstance value, $Res Function(EnumInstance) then) =
+      _$EnumInstanceCopyWithImpl<$Res>;
+  @override
+  $Res call(
+      {String type,
+      String value,
+      @nullable Future<void> Function(String) setter,
+      String instanceRefId});
+}
+
+/// @nodoc
+class _$EnumInstanceCopyWithImpl<$Res>
+    extends _$InstanceDetailsCopyWithImpl<$Res>
+    implements $EnumInstanceCopyWith<$Res> {
+  _$EnumInstanceCopyWithImpl(
+      EnumInstance _value, $Res Function(EnumInstance) _then)
+      : super(_value, (v) => _then(v as EnumInstance));
+
+  @override
+  EnumInstance get _value => super._value as EnumInstance;
+
+  @override
+  $Res call({
+    Object type = freezed,
+    Object value = freezed,
+    Object setter = freezed,
+    Object instanceRefId = freezed,
+  }) {
+    return _then(EnumInstance(
+      type: type == freezed ? _value.type : type as String,
+      value: value == freezed ? _value.value : value as String,
+      setter: setter == freezed
+          ? _value.setter
+          : setter as Future<void> Function(String),
+      instanceRefId: instanceRefId == freezed
+          ? _value.instanceRefId
+          : instanceRefId as String,
+    ));
+  }
+}
+
+/// @nodoc
+class _$EnumInstance extends EnumInstance {
+  _$EnumInstance(
+      {@required this.type,
+      @required this.value,
+      @required @nullable this.setter,
+      @required this.instanceRefId})
+      : assert(type != null),
+        assert(value != null),
+        assert(instanceRefId != null),
+        super._();
+
+  @override
+  final String type;
+  @override
+  final String value;
+  @override
+  @nullable
+  final Future<void> Function(String) setter;
+  @override
+  final String instanceRefId;
+
+  @override
+  String toString() {
+    return 'InstanceDetails.enumeration(type: $type, value: $value, setter: $setter, instanceRefId: $instanceRefId)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other is EnumInstance &&
+            (identical(other.type, type) ||
+                const DeepCollectionEquality().equals(other.type, type)) &&
+            (identical(other.value, value) ||
+                const DeepCollectionEquality().equals(other.value, value)) &&
+            (identical(other.setter, setter) ||
+                const DeepCollectionEquality().equals(other.setter, setter)) &&
+            (identical(other.instanceRefId, instanceRefId) ||
+                const DeepCollectionEquality()
+                    .equals(other.instanceRefId, instanceRefId)));
+  }
+
+  @override
+  int get hashCode =>
+      runtimeType.hashCode ^
+      const DeepCollectionEquality().hash(type) ^
+      const DeepCollectionEquality().hash(value) ^
+      const DeepCollectionEquality().hash(setter) ^
+      const DeepCollectionEquality().hash(instanceRefId);
+
+  @JsonKey(ignore: true)
+  @override
+  $EnumInstanceCopyWith<EnumInstance> get copyWith =>
+      _$EnumInstanceCopyWithImpl<EnumInstance>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object>({
+    @required
+        TResult nill(String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult boolean(String displayString, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult number(String displayString, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult string(String displayString, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult map(List<InstanceDetails> keys, int hash, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult list(@nullable int length, int hash, String instanceRefId,
+            @nullable Future<void> Function(String) setter),
+    @required
+        TResult object(
+            List<ObjectField> fields,
+            String type,
+            int hash,
+            String instanceRefId,
+            @nullable Future<void> Function(String) setter,
+            EvalOnDartLibrary evalForInstance),
+    @required
+        TResult enumeration(
+            String type,
+            String value,
+            @nullable Future<void> Function(String) setter,
+            String instanceRefId),
+  }) {
+    assert(nill != null);
+    assert(boolean != null);
+    assert(number != null);
+    assert(string != null);
+    assert(map != null);
+    assert(list != null);
+    assert(object != null);
+    assert(enumeration != null);
+    return enumeration(type, value, setter, instanceRefId);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object>({
+    TResult nill(
+        String instanceRefId, @nullable Future<void> Function(String) setter),
+    TResult boolean(String displayString, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult number(String displayString, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult string(String displayString, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult map(List<InstanceDetails> keys, int hash, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult list(@nullable int length, int hash, String instanceRefId,
+        @nullable Future<void> Function(String) setter),
+    TResult object(
+        List<ObjectField> fields,
+        String type,
+        int hash,
+        String instanceRefId,
+        @nullable Future<void> Function(String) setter,
+        EvalOnDartLibrary evalForInstance),
+    TResult enumeration(String type, String value,
+        @nullable Future<void> Function(String) setter, String instanceRefId),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (enumeration != null) {
+      return enumeration(type, value, setter, instanceRefId);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object>({
+    @required TResult nill(NullInstance value),
+    @required TResult boolean(BoolInstance value),
+    @required TResult number(NumInstance value),
+    @required TResult string(StringInstance value),
+    @required TResult map(MapInstance value),
+    @required TResult list(ListInstance value),
+    @required TResult object(ObjectInstance value),
+    @required TResult enumeration(EnumInstance value),
+  }) {
+    assert(nill != null);
+    assert(boolean != null);
+    assert(number != null);
+    assert(string != null);
+    assert(map != null);
+    assert(list != null);
+    assert(object != null);
+    assert(enumeration != null);
+    return enumeration(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object>({
+    TResult nill(NullInstance value),
+    TResult boolean(BoolInstance value),
+    TResult number(NumInstance value),
+    TResult string(StringInstance value),
+    TResult map(MapInstance value),
+    TResult list(ListInstance value),
+    TResult object(ObjectInstance value),
+    TResult enumeration(EnumInstance value),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (enumeration != null) {
+      return enumeration(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class EnumInstance extends InstanceDetails {
+  EnumInstance._() : super._();
+  factory EnumInstance(
+      {@required String type,
+      @required String value,
+      @required @nullable Future<void> Function(String) setter,
+      @required String instanceRefId}) = _$EnumInstance;
+
+  String get type;
+  String get value;
+  @override
+  @nullable
+  Future<void> Function(String) get setter;
+  @override
+  String get instanceRefId;
+  @override
+  @JsonKey(ignore: true)
+  $EnumInstanceCopyWith<EnumInstance> get copyWith;
+}
+
+/// @nodoc
+class _$InstancePathTearOff {
+  const _$InstancePathTearOff();
+
+// ignore: unused_element
+  _InstancePathFromInstanceId fromInstanceId(@nullable String instanceId,
+      {List<PathToProperty> pathToProperty = const []}) {
+    return _InstancePathFromInstanceId(
+      instanceId,
+      pathToProperty: pathToProperty,
+    );
+  }
+
+// ignore: unused_element
+  _InstancePathFromProviderId fromProviderId(String providerId,
+      {List<PathToProperty> pathToProperty = const []}) {
+    return _InstancePathFromProviderId(
+      providerId,
+      pathToProperty: pathToProperty,
+    );
+  }
+
+// ignore: unused_element
+  _InstancePathFromBlocId fromBlocId(String blocId,
+      {List<PathToProperty> pathToProperty = const []}) {
+    return _InstancePathFromBlocId(
+      blocId,
+      pathToProperty: pathToProperty,
+    );
+  }
+}
+
+/// @nodoc
+// ignore: unused_element
+const $InstancePath = _$InstancePathTearOff();
+
+/// @nodoc
+mixin _$InstancePath {
+  List<PathToProperty> get pathToProperty;
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object>({
+    @required
+        TResult fromInstanceId(
+            @nullable String instanceId, List<PathToProperty> pathToProperty),
+    @required
+        TResult fromProviderId(
+            String providerId, List<PathToProperty> pathToProperty),
+    @required
+        TResult fromBlocId(String blocId, List<PathToProperty> pathToProperty),
+  });
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object>({
+    TResult fromInstanceId(
+        @nullable String instanceId, List<PathToProperty> pathToProperty),
+    TResult fromProviderId(
+        String providerId, List<PathToProperty> pathToProperty),
+    TResult fromBlocId(String blocId, List<PathToProperty> pathToProperty),
+    @required TResult orElse(),
+  });
+  @optionalTypeArgs
+  TResult map<TResult extends Object>({
+    @required TResult fromInstanceId(_InstancePathFromInstanceId value),
+    @required TResult fromProviderId(_InstancePathFromProviderId value),
+    @required TResult fromBlocId(_InstancePathFromBlocId value),
+  });
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object>({
+    TResult fromInstanceId(_InstancePathFromInstanceId value),
+    TResult fromProviderId(_InstancePathFromProviderId value),
+    TResult fromBlocId(_InstancePathFromBlocId value),
+    @required TResult orElse(),
+  });
+
+  @JsonKey(ignore: true)
+  $InstancePathCopyWith<InstancePath> get copyWith;
+}
+
+/// @nodoc
+abstract class $InstancePathCopyWith<$Res> {
+  factory $InstancePathCopyWith(
+          InstancePath value, $Res Function(InstancePath) then) =
+      _$InstancePathCopyWithImpl<$Res>;
+  $Res call({List<PathToProperty> pathToProperty});
+}
+
+/// @nodoc
+class _$InstancePathCopyWithImpl<$Res> implements $InstancePathCopyWith<$Res> {
+  _$InstancePathCopyWithImpl(this._value, this._then);
+
+  final InstancePath _value;
+  // ignore: unused_field
+  final $Res Function(InstancePath) _then;
+
+  @override
+  $Res call({
+    Object pathToProperty = freezed,
+  }) {
+    return _then(_value.copyWith(
+      pathToProperty: pathToProperty == freezed
+          ? _value.pathToProperty
+          : pathToProperty as List<PathToProperty>,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$InstancePathFromInstanceIdCopyWith<$Res>
+    implements $InstancePathCopyWith<$Res> {
+  factory _$InstancePathFromInstanceIdCopyWith(
+          _InstancePathFromInstanceId value,
+          $Res Function(_InstancePathFromInstanceId) then) =
+      __$InstancePathFromInstanceIdCopyWithImpl<$Res>;
+  @override
+  $Res call({@nullable String instanceId, List<PathToProperty> pathToProperty});
+}
+
+/// @nodoc
+class __$InstancePathFromInstanceIdCopyWithImpl<$Res>
+    extends _$InstancePathCopyWithImpl<$Res>
+    implements _$InstancePathFromInstanceIdCopyWith<$Res> {
+  __$InstancePathFromInstanceIdCopyWithImpl(_InstancePathFromInstanceId _value,
+      $Res Function(_InstancePathFromInstanceId) _then)
+      : super(_value, (v) => _then(v as _InstancePathFromInstanceId));
+
+  @override
+  _InstancePathFromInstanceId get _value =>
+      super._value as _InstancePathFromInstanceId;
+
+  @override
+  $Res call({
+    Object instanceId = freezed,
+    Object pathToProperty = freezed,
+  }) {
+    return _then(_InstancePathFromInstanceId(
+      instanceId == freezed ? _value.instanceId : instanceId as String,
+      pathToProperty: pathToProperty == freezed
+          ? _value.pathToProperty
+          : pathToProperty as List<PathToProperty>,
+    ));
+  }
+}
+
+/// @nodoc
+class _$_InstancePathFromInstanceId extends _InstancePathFromInstanceId {
+  const _$_InstancePathFromInstanceId(@nullable this.instanceId,
+      {this.pathToProperty = const []})
+      : assert(pathToProperty != null),
+        super._();
+
+  @override
+  @nullable
+  final String instanceId;
+  @JsonKey(defaultValue: const [])
+  @override
+  final List<PathToProperty> pathToProperty;
+
+  @override
+  String toString() {
+    return 'InstancePath.fromInstanceId(instanceId: $instanceId, pathToProperty: $pathToProperty)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other is _InstancePathFromInstanceId &&
+            (identical(other.instanceId, instanceId) ||
+                const DeepCollectionEquality()
+                    .equals(other.instanceId, instanceId)) &&
+            (identical(other.pathToProperty, pathToProperty) ||
+                const DeepCollectionEquality()
+                    .equals(other.pathToProperty, pathToProperty)));
+  }
+
+  @override
+  int get hashCode =>
+      runtimeType.hashCode ^
+      const DeepCollectionEquality().hash(instanceId) ^
+      const DeepCollectionEquality().hash(pathToProperty);
+
+  @JsonKey(ignore: true)
+  @override
+  _$InstancePathFromInstanceIdCopyWith<_InstancePathFromInstanceId>
+      get copyWith => __$InstancePathFromInstanceIdCopyWithImpl<
+          _InstancePathFromInstanceId>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object>({
+    @required
+        TResult fromInstanceId(
+            @nullable String instanceId, List<PathToProperty> pathToProperty),
+    @required
+        TResult fromProviderId(
+            String providerId, List<PathToProperty> pathToProperty),
+    @required
+        TResult fromBlocId(String blocId, List<PathToProperty> pathToProperty),
+  }) {
+    assert(fromInstanceId != null);
+    assert(fromProviderId != null);
+    assert(fromBlocId != null);
+    return fromInstanceId(instanceId, pathToProperty);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object>({
+    TResult fromInstanceId(
+        @nullable String instanceId, List<PathToProperty> pathToProperty),
+    TResult fromProviderId(
+        String providerId, List<PathToProperty> pathToProperty),
+    TResult fromBlocId(String blocId, List<PathToProperty> pathToProperty),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (fromInstanceId != null) {
+      return fromInstanceId(instanceId, pathToProperty);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object>({
+    @required TResult fromInstanceId(_InstancePathFromInstanceId value),
+    @required TResult fromProviderId(_InstancePathFromProviderId value),
+    @required TResult fromBlocId(_InstancePathFromBlocId value),
+  }) {
+    assert(fromInstanceId != null);
+    assert(fromProviderId != null);
+    assert(fromBlocId != null);
+    return fromInstanceId(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object>({
+    TResult fromInstanceId(_InstancePathFromInstanceId value),
+    TResult fromProviderId(_InstancePathFromProviderId value),
+    TResult fromBlocId(_InstancePathFromBlocId value),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (fromInstanceId != null) {
+      return fromInstanceId(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _InstancePathFromInstanceId extends InstancePath {
+  const _InstancePathFromInstanceId._() : super._();
+  const factory _InstancePathFromInstanceId(@nullable String instanceId,
+      {List<PathToProperty> pathToProperty}) = _$_InstancePathFromInstanceId;
+
+  @nullable
+  String get instanceId;
+  @override
+  List<PathToProperty> get pathToProperty;
+  @override
+  @JsonKey(ignore: true)
+  _$InstancePathFromInstanceIdCopyWith<_InstancePathFromInstanceId>
+      get copyWith;
+}
+
+/// @nodoc
+abstract class _$InstancePathFromProviderIdCopyWith<$Res>
+    implements $InstancePathCopyWith<$Res> {
+  factory _$InstancePathFromProviderIdCopyWith(
+          _InstancePathFromProviderId value,
+          $Res Function(_InstancePathFromProviderId) then) =
+      __$InstancePathFromProviderIdCopyWithImpl<$Res>;
+  @override
+  $Res call({String providerId, List<PathToProperty> pathToProperty});
+}
+
+/// @nodoc
+class __$InstancePathFromProviderIdCopyWithImpl<$Res>
+    extends _$InstancePathCopyWithImpl<$Res>
+    implements _$InstancePathFromProviderIdCopyWith<$Res> {
+  __$InstancePathFromProviderIdCopyWithImpl(_InstancePathFromProviderId _value,
+      $Res Function(_InstancePathFromProviderId) _then)
+      : super(_value, (v) => _then(v as _InstancePathFromProviderId));
+
+  @override
+  _InstancePathFromProviderId get _value =>
+      super._value as _InstancePathFromProviderId;
+
+  @override
+  $Res call({
+    Object providerId = freezed,
+    Object pathToProperty = freezed,
+  }) {
+    return _then(_InstancePathFromProviderId(
+      providerId == freezed ? _value.providerId : providerId as String,
+      pathToProperty: pathToProperty == freezed
+          ? _value.pathToProperty
+          : pathToProperty as List<PathToProperty>,
+    ));
+  }
+}
+
+/// @nodoc
+class _$_InstancePathFromProviderId extends _InstancePathFromProviderId {
+  const _$_InstancePathFromProviderId(this.providerId,
+      {this.pathToProperty = const []})
+      : assert(providerId != null),
+        assert(pathToProperty != null),
+        super._();
+
+  @override
+  final String providerId;
+  @JsonKey(defaultValue: const [])
+  @override
+  final List<PathToProperty> pathToProperty;
+
+  @override
+  String toString() {
+    return 'InstancePath.fromProviderId(providerId: $providerId, pathToProperty: $pathToProperty)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other is _InstancePathFromProviderId &&
+            (identical(other.providerId, providerId) ||
+                const DeepCollectionEquality()
+                    .equals(other.providerId, providerId)) &&
+            (identical(other.pathToProperty, pathToProperty) ||
+                const DeepCollectionEquality()
+                    .equals(other.pathToProperty, pathToProperty)));
+  }
+
+  @override
+  int get hashCode =>
+      runtimeType.hashCode ^
+      const DeepCollectionEquality().hash(providerId) ^
+      const DeepCollectionEquality().hash(pathToProperty);
+
+  @JsonKey(ignore: true)
+  @override
+  _$InstancePathFromProviderIdCopyWith<_InstancePathFromProviderId>
+      get copyWith => __$InstancePathFromProviderIdCopyWithImpl<
+          _InstancePathFromProviderId>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object>({
+    @required
+        TResult fromInstanceId(
+            @nullable String instanceId, List<PathToProperty> pathToProperty),
+    @required
+        TResult fromProviderId(
+            String providerId, List<PathToProperty> pathToProperty),
+    @required
+        TResult fromBlocId(String blocId, List<PathToProperty> pathToProperty),
+  }) {
+    assert(fromInstanceId != null);
+    assert(fromProviderId != null);
+    assert(fromBlocId != null);
+    return fromProviderId(providerId, pathToProperty);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object>({
+    TResult fromInstanceId(
+        @nullable String instanceId, List<PathToProperty> pathToProperty),
+    TResult fromProviderId(
+        String providerId, List<PathToProperty> pathToProperty),
+    TResult fromBlocId(String blocId, List<PathToProperty> pathToProperty),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (fromProviderId != null) {
+      return fromProviderId(providerId, pathToProperty);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object>({
+    @required TResult fromInstanceId(_InstancePathFromInstanceId value),
+    @required TResult fromProviderId(_InstancePathFromProviderId value),
+    @required TResult fromBlocId(_InstancePathFromBlocId value),
+  }) {
+    assert(fromInstanceId != null);
+    assert(fromProviderId != null);
+    assert(fromBlocId != null);
+    return fromProviderId(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object>({
+    TResult fromInstanceId(_InstancePathFromInstanceId value),
+    TResult fromProviderId(_InstancePathFromProviderId value),
+    TResult fromBlocId(_InstancePathFromBlocId value),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (fromProviderId != null) {
+      return fromProviderId(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _InstancePathFromProviderId extends InstancePath {
+  const _InstancePathFromProviderId._() : super._();
+  const factory _InstancePathFromProviderId(String providerId,
+      {List<PathToProperty> pathToProperty}) = _$_InstancePathFromProviderId;
+
+  String get providerId;
+  @override
+  List<PathToProperty> get pathToProperty;
+  @override
+  @JsonKey(ignore: true)
+  _$InstancePathFromProviderIdCopyWith<_InstancePathFromProviderId>
+      get copyWith;
+}
+
+/// @nodoc
+abstract class _$InstancePathFromBlocIdCopyWith<$Res>
+    implements $InstancePathCopyWith<$Res> {
+  factory _$InstancePathFromBlocIdCopyWith(_InstancePathFromBlocId value,
+          $Res Function(_InstancePathFromBlocId) then) =
+      __$InstancePathFromBlocIdCopyWithImpl<$Res>;
+  @override
+  $Res call({String blocId, List<PathToProperty> pathToProperty});
+}
+
+/// @nodoc
+class __$InstancePathFromBlocIdCopyWithImpl<$Res>
+    extends _$InstancePathCopyWithImpl<$Res>
+    implements _$InstancePathFromBlocIdCopyWith<$Res> {
+  __$InstancePathFromBlocIdCopyWithImpl(_InstancePathFromBlocId _value,
+      $Res Function(_InstancePathFromBlocId) _then)
+      : super(_value, (v) => _then(v as _InstancePathFromBlocId));
+
+  @override
+  _InstancePathFromBlocId get _value => super._value as _InstancePathFromBlocId;
+
+  @override
+  $Res call({
+    Object blocId = freezed,
+    Object pathToProperty = freezed,
+  }) {
+    return _then(_InstancePathFromBlocId(
+      blocId == freezed ? _value.blocId : blocId as String,
+      pathToProperty: pathToProperty == freezed
+          ? _value.pathToProperty
+          : pathToProperty as List<PathToProperty>,
+    ));
+  }
+}
+
+/// @nodoc
+class _$_InstancePathFromBlocId extends _InstancePathFromBlocId {
+  const _$_InstancePathFromBlocId(this.blocId, {this.pathToProperty = const []})
+      : assert(blocId != null),
+        assert(pathToProperty != null),
+        super._();
+
+  @override
+  final String blocId;
+  @JsonKey(defaultValue: const [])
+  @override
+  final List<PathToProperty> pathToProperty;
+
+  @override
+  String toString() {
+    return 'InstancePath.fromBlocId(blocId: $blocId, pathToProperty: $pathToProperty)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other is _InstancePathFromBlocId &&
+            (identical(other.blocId, blocId) ||
+                const DeepCollectionEquality().equals(other.blocId, blocId)) &&
+            (identical(other.pathToProperty, pathToProperty) ||
+                const DeepCollectionEquality()
+                    .equals(other.pathToProperty, pathToProperty)));
+  }
+
+  @override
+  int get hashCode =>
+      runtimeType.hashCode ^
+      const DeepCollectionEquality().hash(blocId) ^
+      const DeepCollectionEquality().hash(pathToProperty);
+
+  @JsonKey(ignore: true)
+  @override
+  _$InstancePathFromBlocIdCopyWith<_InstancePathFromBlocId> get copyWith =>
+      __$InstancePathFromBlocIdCopyWithImpl<_InstancePathFromBlocId>(
+          this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object>({
+    @required
+        TResult fromInstanceId(
+            @nullable String instanceId, List<PathToProperty> pathToProperty),
+    @required
+        TResult fromProviderId(
+            String providerId, List<PathToProperty> pathToProperty),
+    @required
+        TResult fromBlocId(String blocId, List<PathToProperty> pathToProperty),
+  }) {
+    assert(fromInstanceId != null);
+    assert(fromProviderId != null);
+    assert(fromBlocId != null);
+    return fromBlocId(blocId, pathToProperty);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object>({
+    TResult fromInstanceId(
+        @nullable String instanceId, List<PathToProperty> pathToProperty),
+    TResult fromProviderId(
+        String providerId, List<PathToProperty> pathToProperty),
+    TResult fromBlocId(String blocId, List<PathToProperty> pathToProperty),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (fromBlocId != null) {
+      return fromBlocId(blocId, pathToProperty);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object>({
+    @required TResult fromInstanceId(_InstancePathFromInstanceId value),
+    @required TResult fromProviderId(_InstancePathFromProviderId value),
+    @required TResult fromBlocId(_InstancePathFromBlocId value),
+  }) {
+    assert(fromInstanceId != null);
+    assert(fromProviderId != null);
+    assert(fromBlocId != null);
+    return fromBlocId(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object>({
+    TResult fromInstanceId(_InstancePathFromInstanceId value),
+    TResult fromProviderId(_InstancePathFromProviderId value),
+    TResult fromBlocId(_InstancePathFromBlocId value),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (fromBlocId != null) {
+      return fromBlocId(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _InstancePathFromBlocId extends InstancePath {
+  const _InstancePathFromBlocId._() : super._();
+  const factory _InstancePathFromBlocId(String blocId,
+      {List<PathToProperty> pathToProperty}) = _$_InstancePathFromBlocId;
+
+  String get blocId;
+  @override
+  List<PathToProperty> get pathToProperty;
+  @override
+  @JsonKey(ignore: true)
+  _$InstancePathFromBlocIdCopyWith<_InstancePathFromBlocId> get copyWith;
+}

--- a/packages/devtools_app/lib/src/bloc/instance_viewer/instance_providers.dart
+++ b/packages/devtools_app/lib/src/bloc/instance_viewer/instance_providers.dart
@@ -1,0 +1,471 @@
+// Copyright 2021 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:collection/collection.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:pedantic/pedantic.dart';
+import 'package:vm_service/vm_service.dart' hide SentinelException;
+
+import '../../eval_on_dart_library.dart';
+import '../../globals.dart';
+import '../../utils.dart';
+import 'eval.dart';
+import 'instance_details.dart';
+import 'provider_debounce.dart';
+import 'result.dart';
+
+Future<InstanceRef> _resolveInstanceRefForPath(
+  InstancePath path, {
+  @required AutoDisposeProviderReference ref,
+  @required Disposable isAlive,
+  @required InstanceDetails parent,
+}) async {
+  // root of the provider tree
+  if (path.pathToProperty.isEmpty) {
+    return path.map(
+      fromProviderId: (path) async {
+        final eval = await ref.watch(providerEvalProvider.future);
+        // cause the instances to be re-evaluated when the devtool is notified
+        // that a provider changed
+        ref.watch(_providerChanged(path.providerId));
+
+        return eval.safeEval(
+          'ProviderBinding.debugInstance.providerDetails["${path.providerId}"]?.value',
+          isAlive: isAlive,
+        );
+      },
+      fromInstanceId: (path) async {
+        if (path.instanceId == null) return null;
+
+        final eval = await ref.watch(evalProvider.future);
+        return eval.safeEval(
+          'value',
+          isAlive: isAlive,
+          scope: {'value': path.instanceId},
+        );
+      },
+
+      // Listen for changes to all active blocs and return an Instance of the bloc specified by path.blocId
+      fromBlocId: (path) async {
+        if (path.blocId == null) return null;
+
+        final eval = await ref.watch(blocEvalProvider.future);
+
+        ref.watch(_blocChanged(path.blocId));
+        return eval.safeEval('Bloc.observer.blocMap["${path.blocId}"]?.state',
+            isAlive: isAlive);
+      },
+    );
+  }
+
+  final eval = await ref.watch(evalProvider.future);
+
+  return parent.maybeMap(
+    // TODO: support sets
+    // TODO: iterables should use iterators / next() for iterable to navigate, to avoid recomputing the content
+
+    map: (parent) {
+      final keyPath = path.pathToProperty.last as MapKeyPath;
+      final key = keyPath.ref == null ? 'null' : 'key';
+
+      return eval.safeEval(
+        'parent[$key]',
+        isAlive: isAlive,
+        scope: {
+          'parent': parent.instanceRefId,
+          if (keyPath.ref != null) 'key': keyPath.ref
+        },
+      );
+    },
+    list: (parent) {
+      final indexPath = path.pathToProperty.last as ListIndexPath;
+
+      return eval.safeEval(
+        'parent[${indexPath.index}]',
+        isAlive: isAlive,
+        scope: {'parent': parent.instanceRefId},
+      );
+    },
+    object: (parent) async {
+      final propertyPath = path.pathToProperty.last as PropertyPath;
+
+      // compare by both name and ref ID because an object may have multiple
+      // fields with the same name
+      final field = parent.fields.firstWhere((element) =>
+          element.name == propertyPath.name &&
+          element.ownerName == propertyPath.ownerName &&
+          element.ownerUri == propertyPath.ownerUri);
+
+      final ref = field.ref.dataOrThrow;
+      if (ref == null) return null;
+
+      // we cannot do `eval('parent.propertyName')` because it is possible for
+      // objects to have multiple properties with the same name
+      return eval.getInstance(ref, isAlive);
+    },
+    orElse: () => throw FallThroughError(),
+  );
+}
+
+/// Update a variable using the `=` operator.
+///
+/// In rare cases, it is possible for this function to mutate the wrong property.
+/// This can happen when an object contains multiple fields with the same name
+/// (such as private properties or overriden properties), where the conflicting
+/// fields are both defined in the same library.
+Future<void> _mutate(
+  String newValueExpression, {
+  @required InstancePath path,
+  @required AutoDisposeProviderReference ref,
+  @required Disposable isAlive,
+  @required InstanceDetails parent,
+}) async {
+  await parent.maybeMap(
+    list: (parent) async {
+      final eval = await ref.watch(evalProvider.future);
+      final indexPath = path.pathToProperty.last as ListIndexPath;
+
+      return eval.safeEval(
+        'parent[${indexPath.index}] = $newValueExpression',
+        isAlive: isAlive,
+        scope: {
+          'parent': parent.instanceRefId,
+        },
+      );
+    },
+    map: (parent) async {
+      final eval = await ref.watch(evalProvider.future);
+      final keyPath = path.pathToProperty.last as MapKeyPath;
+      final keyRefVar = keyPath.ref == null ? 'null' : 'key';
+
+      return eval.safeEval(
+        'parent[$keyRefVar] = $newValueExpression',
+        isAlive: isAlive,
+        scope: {
+          'parent': parent.instanceRefId,
+          if (keyPath.ref != null) 'key': keyPath.ref,
+        },
+      );
+    },
+    // TODO test can mutate properties of a mixin placed in a different library that the class that uses it
+    object: (parent) {
+      final propertyPath = path.pathToProperty.last as PropertyPath;
+
+      final field = parent.fields.firstWhere((f) =>
+          f.name == propertyPath.name && f.ownerName == propertyPath.ownerName);
+
+      return field.eval.safeEval(
+        'parent.${propertyPath.name} = $newValueExpression',
+        isAlive: isAlive,
+        scope: {
+          'parent': parent.instanceRefId,
+        },
+      );
+    },
+    orElse: () => throw StateError('Can only mutate lists/maps/objects'),
+  );
+
+  // TODO(rrousselGit): call notifyListeners/setState/notifyClients based on the modified object
+
+  // Since the same object can be used in multiple locations at once, we need
+  // to refresh the entire tree instead of just the node that was modified.
+  unawaited(ref.container.refresh(rawInstanceProvider(path.root)));
+
+  // Forces the UI to rebuild after the state change
+  await serviceManager.performHotReload();
+}
+
+Future<InstanceDetails> _resolveParent(
+  AutoDisposeProviderReference ref,
+  InstancePath path,
+) async {
+  return path.pathToProperty.isNotEmpty
+      ? await ref.watch(rawInstanceProvider(path.parent).future)
+      : null;
+}
+
+Future<EnumInstance> _tryParseEnum(
+  Instance instance, {
+  @required EvalOnDartLibrary eval,
+  @required Disposable isAlive,
+  @required String instanceRefId,
+  @required Setter setter,
+}) async {
+  if (instance.kind != InstanceKind.kPlainInstance ||
+      instance.fields.length != 2) return null;
+
+  InstanceRef findPropertyWithName(String name) {
+    return instance.fields
+        .firstWhereOrNull((element) => element.decl.name == name)
+        ?.value;
+  }
+
+  final _nameRef = findPropertyWithName('_name');
+  final indexRef = findPropertyWithName('index');
+
+  if (_nameRef == null || indexRef == null) return null;
+
+  final nameInstanceFuture = eval.getInstance(_nameRef, isAlive);
+  final indexInstanceFuture = eval.getInstance(indexRef, isAlive);
+
+  final index = await indexInstanceFuture;
+
+  if (index.kind != InstanceKind.kInt) return null;
+
+  final name = await nameInstanceFuture;
+  if (name.kind != InstanceKind.kString) return null;
+
+  final nameSplit = name.valueAsString.split('.');
+
+  if (nameSplit.length > 2) return null;
+
+  return EnumInstance(
+    type: nameSplit.first,
+    value: nameSplit[1],
+    instanceRefId: instanceRefId,
+    setter: setter,
+  );
+}
+
+// Setter is responsible for mutating fields in an Instance
+Setter _parseSetter({
+  @required InstancePath path,
+  @required ProviderReference ref,
+  @required Disposable isAlive,
+  @required InstanceDetails parent,
+}) {
+  if (parent == null) return null;
+
+  Future<void> mutate(String expression) {
+    return _mutate(
+      expression,
+      path: path,
+      ref: ref,
+      isAlive: isAlive,
+      parent: parent,
+    );
+  }
+
+  return parent.maybeMap(
+    // TODO const collections should have no setter
+    map: (parent) => mutate,
+    list: (parent) => mutate,
+    object: (parent) {
+      final keyPath = path.pathToProperty.last as PropertyPath;
+
+      // Mutate properties by name as we can't mutate them from a reference.
+      // This may edit the wrong property when an object has two properties with
+      // with the same name.
+      // TODO use ownerUri
+      final field =
+          parent.fields.firstWhere((field) => field.name == keyPath.name);
+
+      if (field.isFinal) return null;
+      return mutate;
+    },
+    orElse: () => throw FallThroughError(),
+  );
+}
+
+/// Fetches informations related to an instance/provider at a given path
+///
+/// The UI should not be used directly. Instead, use [instanceProvider].
+final AutoDisposeFutureProviderFamily<InstanceDetails, InstancePath>
+    rawInstanceProvider =
+    AutoDisposeFutureProviderFamily<InstanceDetails, InstancePath>(
+        (ref, path) async {
+  ref.watch(hotRestartEventProvider);
+
+  final eval = await ref.watch(evalProvider.future);
+
+  final isAlive = Disposable();
+  ref.onDispose(isAlive.dispose);
+
+  final parent = await _resolveParent(ref, path);
+
+  InstanceRef instanceRef;
+
+  instanceRef = await _resolveInstanceRefForPath(
+    path,
+    ref: ref,
+    parent: parent,
+    isAlive: isAlive,
+  );
+
+  final setter = _parseSetter(
+    path: path,
+    isAlive: isAlive,
+    ref: ref,
+    parent: parent,
+  );
+
+  final instance = await eval.getInstance(instanceRef, isAlive);
+
+  switch (instance.kind) {
+    case InstanceKind.kNull:
+      return InstanceDetails.nill(setter: setter);
+    case InstanceKind.kBool:
+      return InstanceDetails.boolean(
+        instance.valueAsString,
+        instanceRefId: instanceRef.id,
+        setter: setter,
+      );
+    case InstanceKind.kInt:
+    case InstanceKind.kDouble:
+      return InstanceDetails.number(
+        instance.valueAsString,
+        instanceRefId: instanceRef.id,
+        setter: setter,
+      );
+    case InstanceKind.kString:
+      return InstanceDetails.string(
+        instance.valueAsString,
+        instanceRefId: instanceRef.id,
+        setter: setter,
+      );
+
+    case InstanceKind.kMap:
+
+      // voluntarily throw if a key failed to load
+      final keysRef = instance.associations.map((e) => e.key as InstanceRef);
+
+      final keysFuture = Future.wait<InstanceDetails>([
+        for (final keyRef in keysRef)
+          ref.watch(
+            rawInstanceProvider(InstancePath.fromInstanceId(keyRef?.id)).future,
+          )
+      ]);
+
+      return InstanceDetails.map(
+        await keysFuture,
+        hash: await eval.getHashCode(instance, isAlive: isAlive),
+        instanceRefId: instanceRef.id,
+        setter: setter,
+      );
+
+    // TODO(rrousselGit): support sets
+    // TODO(rrousselGit): support custom lists
+    // TODO(rrousselGit): support Type
+    case InstanceKind.kList:
+      return InstanceDetails.list(
+        length: instance.length,
+        hash: await eval.getHashCode(instance, isAlive: isAlive),
+        instanceRefId: instanceRef.id,
+        setter: setter,
+      );
+
+    case InstanceKind.kPlainInstance:
+    default:
+      final enumDetails = await _tryParseEnum(
+        instance,
+        eval: eval,
+        isAlive: isAlive,
+        instanceRefId: instanceRef.id,
+        setter: setter,
+      );
+
+      if (enumDetails != null) return enumDetails;
+
+      final classInstance = await eval.getClass(instance.classRef, isAlive);
+      final evalForInstance =
+          ref.watch(libraryEvalProvider(classInstance.library.uri).future);
+
+      final appName = tryParsePackageName(eval.isolate.rootLib.uri);
+
+      final fields = await _parseFields(
+        ref,
+        eval,
+        instance,
+        classInstance,
+        isAlive: isAlive,
+        appName: appName,
+      );
+
+      return InstanceDetails.object(
+        fields.sorted((a, b) => sortFieldsByName(a.name, b.name)),
+        hash: await eval.getHashCode(instance, isAlive: isAlive),
+        type: instance.classRef.name,
+        instanceRefId: instanceRef.id,
+        evalForInstance: await evalForInstance,
+        setter: setter,
+      );
+  }
+});
+
+/// [rawInstanceProvider] but the loading state is debounced for one second.
+///
+/// This avoids flickers when a state is refreshed
+final instanceProvider =
+    familyAsyncDebounce<AsyncValue<InstanceDetails>, InstancePath>(
+  rawInstanceProvider,
+);
+
+final _packageNameExp = RegExp(
+  r'package:(.+?)/',
+);
+
+String tryParsePackageName(String uri) {
+  return _packageNameExp.firstMatch(uri)?.group(1);
+}
+
+Future<List<ObjectField>> _parseFields(
+  AutoDisposeProviderReference ref,
+  EvalOnDartLibrary eval,
+  Instance instance,
+  Class classInstance, {
+  @required Disposable isAlive,
+  @required String appName,
+}) async {
+  final fields = instance.fields.map((field) async {
+    final owner = await eval.getClass(field.decl.owner, isAlive);
+
+    String ownerUri;
+    String ownerName;
+    if (owner.mixin == null) {
+      ownerUri = owner.library.uri;
+      ownerName = owner.name;
+    } else {
+      final mixinClass = await eval.getClass(owner.mixin.typeClass, isAlive);
+
+      ownerUri = mixinClass.library.uri;
+      ownerName = mixinClass.name;
+    }
+
+    final ownerPackageName = tryParsePackageName(ownerUri);
+
+    return ObjectField(
+      name: field.decl.name,
+      isFinal: field.decl.isFinal,
+      ref: parseSentinel<InstanceRef>(field.value),
+      ownerName: ownerName,
+      ownerUri: ownerUri,
+      eval: await ref.watch(libraryEvalProvider(owner.library.uri).future),
+      isDefinedByDependency: ownerPackageName != appName,
+    );
+  }).toList();
+
+  return Future.wait(fields);
+}
+
+final _providerChanged =
+    AutoDisposeStreamProviderFamily<void, String>((ref, id) async* {
+  final service = await ref.watch(serviceProvider.last);
+
+  yield* service.onExtensionEvent.where((event) {
+    return event.extensionKind == 'provider:provider_changed' &&
+        event.extensionData.data['id'] == id;
+  });
+});
+
+final _blocChanged =
+    AutoDisposeStreamProviderFamily<void, String>((ref, id) async* {
+  final service = await ref.watch(serviceProvider.last);
+
+  yield* service.onExtensionEvent.where((event) {
+    return event.extensionKind == 'bloc:bloc_map_changed';
+  });
+});

--- a/packages/devtools_app/lib/src/bloc/instance_viewer/instance_viewer.dart
+++ b/packages/devtools_app/lib/src/bloc/instance_viewer/instance_viewer.dart
@@ -1,0 +1,655 @@
+// Copyright 2021 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// TODO(rrousselGit) merge this code with the debugger view
+
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../eval_on_dart_library.dart';
+import '../../inspector/inspector_text_styles.dart';
+import '../../sliver_iterable_child_delegate.dart';
+import '../../theme.dart';
+import 'instance_details.dart';
+import 'instance_providers.dart';
+
+const typeColor = Color.fromARGB(255, 78, 201, 176);
+const boolColor = Color.fromARGB(255, 86, 156, 214);
+const nullColor = boolColor;
+const numColor = Color.fromARGB(255, 181, 206, 168);
+const stringColor = Color.fromARGB(255, 206, 145, 120);
+const propertyColor = Color.fromARGB(255, 206, 145, 120);
+
+const double rowHeight = 20.0;
+
+final isExpandedProvider = StateProviderFamily<bool, InstancePath>((ref, path) {
+  // expands the root by default, but not children
+  return path.pathToProperty.isEmpty;
+});
+
+final estimatedChildCountProvider =
+    AutoDisposeProviderFamily<int, InstancePath>((ref, rootPath) {
+  int estimatedChildCount(InstancePath path) {
+    int one(InstanceDetails instance) => 1;
+
+    int expandableEstimatedChildCount(Iterable<PathToProperty> keys) {
+      if (!ref.watch(isExpandedProvider(path)).state) {
+        return 1;
+      }
+      return keys.fold(1, (acc, element) {
+        return acc +
+            estimatedChildCount(
+              path.pathForChild(element),
+            );
+      });
+    }
+
+    return ref.watch(instanceProvider(path)).when(
+          loading: () => 1,
+          error: (err, stack) => 1,
+          data: (instance) {
+            return instance.map(
+              nill: one,
+              boolean: one,
+              number: one,
+              string: one,
+              enumeration: one,
+              map: (instance) {
+                return expandableEstimatedChildCount(
+                  instance.keys.map(
+                      (key) => PathToProperty.mapKey(ref: key.instanceRefId)),
+                );
+              },
+              list: (instance) {
+                return expandableEstimatedChildCount(
+                  List.generate(instance.length, $PathToProperty.listIndex),
+                );
+              },
+              object: (instance) {
+                return expandableEstimatedChildCount(
+                  instance.fields.map(
+                    (field) => PathToProperty.fromObjectField(field),
+                  ),
+                );
+              },
+            );
+          },
+        );
+  }
+
+  return estimatedChildCount(rootPath);
+});
+
+void showErrorSnackBar(BuildContext context, Object error) {
+  ScaffoldMessenger.of(context).showSnackBar(
+    SnackBar(content: Text('Error: $error')),
+  );
+}
+
+class InstanceViewer extends StatefulWidget {
+  const InstanceViewer({
+    Key key,
+    this.rootPath,
+    @required this.showInternalProperties,
+  }) : super(key: key);
+
+  final InstancePath rootPath;
+  final bool showInternalProperties;
+
+  @override
+  _InstanceViewerState createState() => _InstanceViewerState();
+}
+
+class _InstanceViewerState extends State<InstanceViewer> {
+  final scrollController = ScrollController();
+
+  @override
+  void dispose() {
+    scrollController.dispose();
+    super.dispose();
+  }
+
+  Iterable<Widget> _buildError(
+    Object error,
+    StackTrace stackTrace,
+    InstancePath path,
+  ) {
+    if (error is SentinelException) {
+      return [Text(error.sentinel.valueAsString)];
+    }
+
+    return const [Text('<unknown error>')];
+  }
+
+  Iterable<Widget> _buildListViewItems(
+    BuildContext context,
+    ScopedReader watch, {
+    @required InstancePath path,
+    bool disableExpand = false,
+  }) {
+    return watch(instanceProvider(path)).when(
+      loading: () => const [Text('loading...')],
+      error: (err, stack) => _buildError(err, stack, path),
+      data: (instance) sync* {
+        final isExpanded = watch(isExpandedProvider(path));
+        yield _buildHeader(
+          instance,
+          path: path,
+          isExpanded: isExpanded,
+          disableExpand: disableExpand,
+        );
+
+        if (isExpanded.state) {
+          yield* instance.maybeMap(
+            object: (instance) => _buildObjectItem(
+              context,
+              watch,
+              instance,
+              path: path,
+            ),
+            list: (list) => _buildListItem(
+              context,
+              watch,
+              instance,
+              path: path,
+            ),
+            map: (map) => _buildMapItem(
+              context,
+              watch,
+              instance,
+              path: path,
+            ),
+            // string/numbers/bools have no children, but this code can be reached
+            // when the root of the instance tree (which is always expanded) is such primitive.
+            orElse: () => const [],
+          );
+        }
+      },
+    );
+  }
+
+  Widget _buildHeader(
+    InstanceDetails instance, {
+    @required InstancePath path,
+    StateController<bool> isExpanded,
+    bool disableExpand = false,
+  }) {
+    return _Expandable(
+      key: ValueKey(path),
+      isExpandable: !disableExpand && instance.isExpandable,
+      isExpanded: isExpanded,
+      title: instance.map(
+        enumeration: (instance) => _EditableField(
+          setter: instance.setter,
+          initialEditString: '${instance.type}.${instance.value}',
+          child: Text.rich(
+            TextSpan(
+              children: [
+                TextSpan(
+                  text: instance.type,
+                  style: const TextStyle(color: typeColor),
+                ),
+                TextSpan(text: '.${instance.value}'),
+              ],
+            ),
+          ),
+        ),
+        nill: (instance) => _EditableField(
+          setter: instance.setter,
+          initialEditString: 'null',
+          child: const Text('null', style: TextStyle(color: nullColor)),
+        ),
+        string: (instance) => _EditableField(
+          setter: instance.setter,
+          initialEditString: '"${instance.displayString}"',
+          child: Text.rich(
+            TextSpan(
+              children: [
+                const TextSpan(text: '"'),
+                TextSpan(
+                  text: instance.displayString,
+                  style: const TextStyle(color: stringColor),
+                ),
+                const TextSpan(text: '"'),
+              ],
+            ),
+          ),
+        ),
+        number: (instance) => _EditableField(
+          setter: instance.setter,
+          initialEditString: instance.displayString,
+          child: Text(
+            instance.displayString,
+            style: const TextStyle(color: numColor),
+          ),
+        ),
+        boolean: (instance) => _EditableField(
+          setter: instance.setter,
+          initialEditString: instance.displayString,
+          child: Text(
+            instance.displayString,
+            style: const TextStyle(color: boolColor),
+          ),
+        ),
+        map: (instance) => _ObjectHeader(
+          startToken: '{',
+          endToken: '}',
+          hash: instance.hash,
+          meta: instance.keys.isEmpty
+              ? null
+              : instance.keys.length == 1
+                  ? '1 element'
+                  : '${instance.keys.length} elements',
+        ),
+        list: (instance) => _ObjectHeader(
+          startToken: '[',
+          endToken: ']',
+          hash: instance.hash,
+          meta: instance.length == 0
+              ? null
+              : instance.length == 1
+                  ? '1 element'
+                  : '${instance.length} elements',
+        ),
+        object: (instance) => _ObjectHeader(
+          type: instance.type,
+          hash: instance.hash,
+          startToken: '',
+          endToken: '',
+          // Never show the number of elements when using custom objects
+          meta: null,
+        ),
+      ),
+    );
+  }
+
+  Iterable<Widget> _buildMapItem(
+    BuildContext context,
+    ScopedReader watch,
+    MapInstance instance, {
+    @required InstancePath path,
+  }) sync* {
+    for (final key in instance.keys) {
+      final value = _buildListViewItems(
+        context,
+        watch,
+        path: path.pathForChild(PathToProperty.mapKey(ref: key.instanceRefId)),
+      );
+
+      final keyHeader = _buildHeader(key, disableExpand: true, path: path);
+
+      var isFirstItem = true;
+      for (final child in value) {
+        yield Padding(
+          padding: const EdgeInsets.only(left: defaultSpacing),
+          child: isFirstItem
+              ? Row(
+                  children: [
+                    keyHeader,
+                    const Text(': '),
+                    Expanded(child: child),
+                  ],
+                )
+              : child,
+        );
+
+        isFirstItem = false;
+      }
+
+      assert(
+        !isFirstItem,
+        'Bad state: the value of $key did not render any widget',
+      );
+    }
+  }
+
+  Iterable<Widget> _buildListItem(
+    BuildContext context,
+    ScopedReader watch,
+    ListInstance instance, {
+    @required InstancePath path,
+  }) sync* {
+    for (var index = 0; index < instance.length; index++) {
+      final children = _buildListViewItems(
+        context,
+        watch,
+        path: path.pathForChild(PathToProperty.listIndex(index)),
+      );
+
+      bool isFirst = true;
+
+      for (final child in children) {
+        Widget rowItem = child;
+
+        // Add the item index only on the first line of the element
+        if (isFirst) {
+          isFirst = false;
+          rowItem = Row(
+            children: [
+              Text('[$index]: '),
+              Expanded(child: rowItem),
+            ],
+          );
+        }
+
+        yield Padding(
+          padding: const EdgeInsets.only(left: defaultSpacing),
+          child: rowItem,
+        );
+      }
+    }
+  }
+
+  // Iterable<Widget> _buildPrimitiveItem(
+  //   BuildContext context,
+  //   ScopedReader watch,
+  //   NumInstance instance, {
+  //   @required InstancePath path,
+  // }) sync* {
+  //   Row(
+  //     children: [Text('${instance.displayString}')],
+  //   );
+  // }
+
+  Iterable<Widget> _buildObjectItem(
+    BuildContext context,
+    ScopedReader watch,
+    ObjectInstance instance, {
+    @required InstancePath path,
+  }) sync* {
+    for (final field in instance.fields) {
+      if (!widget.showInternalProperties &&
+          field.isDefinedByDependency &&
+          field.isPrivate) {
+        // Hide private properties from classes defined by dependencies
+        continue;
+      }
+
+      final children = _buildListViewItems(
+        context,
+        watch,
+        path: path.pathForChild(PathToProperty.fromObjectField(field)),
+      );
+
+      bool isFirst = true;
+
+      for (final child in children) {
+        Widget rowItem = child;
+        if (isFirst) {
+          isFirst = false;
+          rowItem = Row(
+            children: [
+              if (field.isFinal)
+                Text(
+                  'final ',
+                  style: unimportant(Theme.of(context).colorScheme),
+                ),
+              Text('${field.name}: '),
+              Expanded(child: rowItem),
+            ],
+          );
+        }
+
+        yield Padding(
+          padding: const EdgeInsets.only(left: defaultSpacing),
+          child: rowItem,
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer(
+      builder: (context, watch, _) {
+        return Scrollbar(
+          isAlwaysShown: true,
+          controller: scrollController,
+          child: ListView.custom(
+            controller: scrollController,
+            // TODO: item height should be based on font size
+            itemExtent: rowHeight,
+            padding: const EdgeInsets.symmetric(
+              vertical: denseSpacing,
+              horizontal: defaultSpacing,
+            ),
+            childrenDelegate: SliverIterableChildDelegate(
+              _buildListViewItems(
+                context,
+                watch,
+                path: widget.rootPath,
+                disableExpand: true,
+              ),
+              estimatedChildCount:
+                  watch(estimatedChildCountProvider(widget.rootPath)),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _ObjectHeader extends StatelessWidget {
+  const _ObjectHeader({
+    Key key,
+    this.type,
+    @required this.hash,
+    @required this.meta,
+    @required this.startToken,
+    @required this.endToken,
+  }) : super(key: key);
+
+  final String type;
+  final int hash;
+  final String meta;
+  final String startToken;
+  final String endToken;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Text.rich(
+      TextSpan(
+        children: [
+          if (type != null)
+            TextSpan(
+              text: type,
+              style: const TextStyle(color: typeColor),
+            ),
+          TextSpan(
+            text: '#${shortHash(hash)}',
+            style: unimportant(colorScheme),
+          ),
+          TextSpan(text: startToken),
+          if (meta != null) TextSpan(text: meta),
+          TextSpan(text: endToken),
+        ],
+      ),
+    );
+  }
+}
+
+class _EditableField extends StatefulWidget {
+  const _EditableField({
+    Key key,
+    @required this.setter,
+    @required this.child,
+    @required this.initialEditString,
+    // @required this.blocEvalOnDart,
+  }) : super(key: key);
+
+  final Widget child;
+  final String initialEditString;
+  final Future<void> Function(String) setter;
+  // final EvalOnDartLibrary blocEvalOnDart;
+
+  @override
+  _EditableFieldState createState() => _EditableFieldState();
+}
+
+class _EditableFieldState extends State<_EditableField> {
+  final controller = TextEditingController();
+  final focusNode = FocusNode();
+  final textFieldFocusNode = FocusNode();
+  var isHovering = false;
+
+  final _isAlive = Disposable();
+
+  @override
+  void dispose() {
+    _isAlive.dispose();
+    controller.dispose();
+    focusNode.dispose();
+    textFieldFocusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // if (widget.setter == null) {
+    //   return widget.child;
+    // }
+
+    final colorScheme = Theme.of(context).colorScheme;
+
+    final editingChild = TextField(
+      autofocus: true,
+      controller: controller,
+      focusNode: textFieldFocusNode,
+      onSubmitted: (value) async {
+        try {
+          if (widget.setter != null) {
+            await widget.setter(value);
+          }
+          // await widget.blocEvalOnDart.safeEval('Bloc.observer.blocMap["${path.blocId}"].}', isAlive: Disposable());
+        } catch (err) {
+          showErrorSnackBar(context, err);
+        }
+      },
+      decoration: InputDecoration(
+        contentPadding: const EdgeInsets.all(densePadding),
+        isDense: true,
+        border: OutlineInputBorder(
+          borderRadius: const BorderRadius.all(Radius.circular(5)),
+          borderSide: BorderSide(color: colorScheme.surface),
+        ),
+      ),
+    );
+
+    final displayChild = Stack(
+      clipBehavior: Clip.none,
+      children: [
+        if (isHovering)
+          Positioned(
+            bottom: -5,
+            left: -5,
+            top: -5,
+            right: -5,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                borderRadius: const BorderRadius.all(
+                  Radius.circular(defaultBorderRadius),
+                ),
+                border: Border.all(color: colorScheme.surface),
+              ),
+            ),
+          ),
+        GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: () {
+            focusNode.requestFocus();
+            textFieldFocusNode.requestFocus();
+            controller.text = widget.initialEditString;
+            controller.selection = TextSelection(
+              baseOffset: 0,
+              extentOffset: widget.initialEditString.length,
+            );
+          },
+          child: Align(
+            alignment: Alignment.centerLeft,
+            heightFactor: 1,
+            child: widget.child,
+          ),
+        ),
+      ],
+    );
+
+    return AnimatedBuilder(
+      animation: focusNode,
+      builder: (context, _) {
+        final isEditing = focusNode.hasFocus;
+
+        return Focus(
+          focusNode: focusNode,
+          onKey: (node, key) {
+            if (key.data.physicalKey == PhysicalKeyboardKey.escape) {
+              focusNode.unfocus();
+              return KeyEventResult.handled;
+            }
+            return KeyEventResult.ignored;
+          },
+          child: MouseRegion(
+            onEnter: (_) => setState(() => isHovering = true),
+            onExit: (_) => setState(() => isHovering = false),
+            // use a Stack to show the borders, to avoid the UI "moving" when hovering
+            child: isEditing ? editingChild : displayChild,
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _Expandable extends StatelessWidget {
+  const _Expandable({
+    Key key,
+    @required this.isExpanded,
+    @required this.isExpandable,
+    @required this.title,
+  }) : super(key: key);
+
+  final StateController isExpanded;
+  final bool isExpandable;
+  final Widget title;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!isExpandable) {
+      return Align(
+        alignment: Alignment.centerLeft,
+        child: title,
+      );
+    }
+
+    return GestureDetector(
+      onTap: () => isExpanded.state = !isExpanded.state,
+      behavior: HitTestBehavior.opaque,
+      child: Row(
+        children: [
+          TweenAnimationBuilder<double>(
+            tween: Tween(end: isExpanded.state ? 0 : -math.pi / 2),
+            duration: defaultDuration,
+            builder: (context, angle, _) {
+              return Transform.rotate(
+                angle: angle,
+                child: const Icon(
+                  Icons.expand_more,
+                  size: defaultIconSize,
+                ),
+              );
+            },
+          ),
+          title,
+        ],
+      ),
+    );
+  }
+}

--- a/packages/devtools_app/lib/src/bloc/instance_viewer/provider_debounce.dart
+++ b/packages/devtools_app/lib/src/bloc/instance_viewer/provider_debounce.dart
@@ -1,0 +1,127 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'eval.dart';
+
+// TODO(rrousselGit) remove once the next Riverpod update is released
+AutoDisposeStateNotifierProviderFamily<StateController<Listened>, Listened, Id>
+    familyAsyncDebounce<Listened extends AsyncValue, Id>(
+  Family<dynamic, Listened, Id, AutoDisposeProviderReference,
+          AutoDisposeProviderBase<dynamic, Listened>>
+      family, {
+  Duration duration = const Duration(seconds: 1),
+}) {
+  return AutoDisposeStateNotifierProviderFamily<StateController<Listened>,
+      Listened, Id>(
+    (ref, id) {
+      ref.watch(hotRestartEventProvider);
+      bool listening = true;
+
+      final controller = StateController<Listened>(
+        // It is safe to use `read` here because the provider is immediately listened after
+        ref.read(family(id)),
+      );
+
+      Timer timer;
+      ref.onDispose(() => timer?.cancel());
+
+      // TODO(rrousselGit): refactor to use `ref.listen` when available
+      final sub = ref.container.listen<Listened>(
+        family(id),
+        mayHaveChanged: (sub) {
+          return Future.microtask(() {
+            if (ref.mounted && listening) sub.flush();
+          });
+        },
+        didChange: (sub) {
+          timer?.cancel();
+
+          final value = sub.read();
+
+          value.map(
+            data: (_) => controller.state = value,
+            error: (_) => controller.state = value,
+            loading: (_) {
+              timer = Timer(const Duration(seconds: 1), () {
+                controller.state = value;
+              });
+            },
+          );
+        },
+      );
+
+      ref.onDispose(() {
+        sub.close();
+        listening = false;
+      });
+      return controller;
+    },
+    // ignore: invalid_use_of_protected_member
+    name: family.name == null
+        ? 'familyDebounced($duration)'
+        // ignore: invalid_use_of_protected_member
+        : '${family.name}.debounced($duration)',
+  );
+}
+
+// TODO(rrousselGit) remove once the next Riverpod update is released
+AutoDisposeStateNotifierProvider<StateController<Listened>, Listened>
+    asyncDebounce<Listened extends AsyncValue>(
+  AutoDisposeProviderBase<dynamic, Listened> provider, {
+  Duration duration = const Duration(seconds: 1),
+}) {
+  return AutoDisposeStateNotifierProvider<StateController<Listened>, Listened>(
+    (ref) {
+      ref.watch(hotRestartEventProvider);
+      bool listening = true;
+
+      final controller = StateController<Listened>(
+        // It is safe to use `read` here because the provider is immediately listened after
+        ref.read(provider),
+      );
+
+      Timer timer;
+      ref.onDispose(() => timer?.cancel());
+
+      // TODO(rrousselGit): refactor to use `ref.listen` when available
+      final sub = ref.container.listen<Listened>(
+        provider,
+        mayHaveChanged: (sub) {
+          return Future.microtask(() {
+            if (ref.mounted && listening) sub.flush();
+          });
+        },
+        didChange: (sub) {
+          timer?.cancel();
+
+          final value = sub.read();
+
+          value.map(
+            data: (_) {
+              controller.state = value;
+            },
+            error: (_) {
+              controller.state = value;
+            },
+            loading: (_) {
+              timer = Timer(const Duration(seconds: 1), () {
+                controller.state = value;
+              });
+            },
+          );
+        },
+      );
+
+      ref.onDispose(() {
+        sub.close();
+        listening = false;
+      });
+
+      return controller;
+    },
+    name: provider.name == null
+        ? 'debounced($duration)'
+        : '${provider.name}.debounced($duration)',
+  );
+}

--- a/packages/devtools_app/lib/src/bloc/instance_viewer/result.dart
+++ b/packages/devtools_app/lib/src/bloc/instance_viewer/result.dart
@@ -1,0 +1,79 @@
+// Copyright 2021 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:collection/collection.dart';
+import 'package:meta/meta.dart';
+import 'package:vm_service/vm_service.dart' hide SentinelException;
+
+import '../../eval_on_dart_library.dart';
+
+import 'fake_freezed_annotation.dart';
+
+// This part is generated using package:freezed, but without the devtool depending
+// on the package.
+// To update the generated files, temporarily add freezed/freezed_annotation/build_runner
+// as dependencies; replace the `fake_freezed_annotation.dart` import with the
+// real annotation package, then execute `pub run build_runner build`.
+part 'result.freezed.dart';
+
+@freezed
+abstract class Result<T> with _$Result<T> {
+  Result._();
+  factory Result.data(@nullable T value) = _ResultData<T>;
+  factory Result.error(Object error, [StackTrace stackTrace]) = _ResultError<T>;
+
+  factory Result.guard(T Function() cb) {
+    try {
+      return Result.data(cb());
+    } catch (err, stack) {
+      return Result.error(err, stack);
+    }
+  }
+
+  static Future<Result<T>> guardFuture<T>(Future<T> Function() cb) async {
+    try {
+      return Result.data(await cb());
+    } catch (err, stack) {
+      return Result.error(err, stack);
+    }
+  }
+
+  Result<Res> chain<Res>(Res Function(T value) cb) {
+    return when(
+      data: (value) {
+        try {
+          return Result.data(cb(value));
+        } catch (err, stack) {
+          return Result.error(err, stack);
+        }
+      },
+      error: (err, stack) => Result.error(err, stack),
+    );
+  }
+
+  T get dataOrThrow {
+    return when(
+      data: (value) => value,
+      error: (err, stack) {
+        // ignore: only_throw_errors
+        throw err;
+      },
+    );
+  }
+}
+
+Result<T> parseSentinel<T>(Object value) {
+  // TODO(rrousselGit) remove condition after migrating to NNBD
+  if (value == null) return Result.data(null);
+  if (value is T) return Result.data(value);
+
+  if (value is Sentinel) {
+    return Result.error(
+      SentinelException(value),
+      StackTrace.current,
+    );
+  }
+
+  return Result.error(value, StackTrace.current);
+}

--- a/packages/devtools_app/lib/src/bloc/instance_viewer/result.freezed.dart
+++ b/packages/devtools_app/lib/src/bloc/instance_viewer/result.freezed.dart
@@ -1,0 +1,327 @@
+// Copyright 2021 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies
+
+part of 'result.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+class _$ResultTearOff {
+  const _$ResultTearOff();
+
+// ignore: unused_element
+  _ResultData<T> data<T>(@nullable T value) {
+    return _ResultData<T>(
+      value,
+    );
+  }
+
+// ignore: unused_element
+  _ResultError<T> error<T>(Object error, [StackTrace stackTrace]) {
+    return _ResultError<T>(
+      error,
+      stackTrace,
+    );
+  }
+}
+
+/// @nodoc
+// ignore: unused_element
+const $Result = _$ResultTearOff();
+
+/// @nodoc
+mixin _$Result<T> {
+  @optionalTypeArgs
+  TResult when<TResult extends Object>({
+    @required TResult data(@nullable T value),
+    @required TResult error(Object error, StackTrace stackTrace),
+  });
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object>({
+    TResult data(@nullable T value),
+    TResult error(Object error, StackTrace stackTrace),
+    @required TResult orElse(),
+  });
+  @optionalTypeArgs
+  TResult map<TResult extends Object>({
+    @required TResult data(_ResultData<T> value),
+    @required TResult error(_ResultError<T> value),
+  });
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object>({
+    TResult data(_ResultData<T> value),
+    TResult error(_ResultError<T> value),
+    @required TResult orElse(),
+  });
+}
+
+/// @nodoc
+abstract class $ResultCopyWith<T, $Res> {
+  factory $ResultCopyWith(Result<T> value, $Res Function(Result<T>) then) =
+      _$ResultCopyWithImpl<T, $Res>;
+}
+
+/// @nodoc
+class _$ResultCopyWithImpl<T, $Res> implements $ResultCopyWith<T, $Res> {
+  _$ResultCopyWithImpl(this._value, this._then);
+
+  final Result<T> _value;
+  // ignore: unused_field
+  final $Res Function(Result<T>) _then;
+}
+
+/// @nodoc
+abstract class _$ResultDataCopyWith<T, $Res> {
+  factory _$ResultDataCopyWith(
+          _ResultData<T> value, $Res Function(_ResultData<T>) then) =
+      __$ResultDataCopyWithImpl<T, $Res>;
+  $Res call({@nullable T value});
+}
+
+/// @nodoc
+class __$ResultDataCopyWithImpl<T, $Res> extends _$ResultCopyWithImpl<T, $Res>
+    implements _$ResultDataCopyWith<T, $Res> {
+  __$ResultDataCopyWithImpl(
+      _ResultData<T> _value, $Res Function(_ResultData<T>) _then)
+      : super(_value, (v) => _then(v as _ResultData<T>));
+
+  @override
+  _ResultData<T> get _value => super._value as _ResultData<T>;
+
+  @override
+  $Res call({
+    Object value = freezed,
+  }) {
+    return _then(_ResultData<T>(
+      value == freezed ? _value.value : value as T,
+    ));
+  }
+}
+
+/// @nodoc
+class _$_ResultData<T> extends _ResultData<T> {
+  _$_ResultData(@nullable this.value) : super._();
+
+  @override
+  @nullable
+  final T value;
+
+  @override
+  String toString() {
+    return 'Result<$T>.data(value: $value)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other is _ResultData<T> &&
+            (identical(other.value, value) ||
+                const DeepCollectionEquality().equals(other.value, value)));
+  }
+
+  @override
+  int get hashCode =>
+      runtimeType.hashCode ^ const DeepCollectionEquality().hash(value);
+
+  @JsonKey(ignore: true)
+  @override
+  _$ResultDataCopyWith<T, _ResultData<T>> get copyWith =>
+      __$ResultDataCopyWithImpl<T, _ResultData<T>>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object>({
+    @required TResult data(@nullable T value),
+    @required TResult error(Object error, StackTrace stackTrace),
+  }) {
+    assert(data != null);
+    assert(error != null);
+    return data(value);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object>({
+    TResult data(@nullable T value),
+    TResult error(Object error, StackTrace stackTrace),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (data != null) {
+      return data(value);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object>({
+    @required TResult data(_ResultData<T> value),
+    @required TResult error(_ResultError<T> value),
+  }) {
+    assert(data != null);
+    assert(error != null);
+    return data(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object>({
+    TResult data(_ResultData<T> value),
+    TResult error(_ResultError<T> value),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (data != null) {
+      return data(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _ResultData<T> extends Result<T> {
+  _ResultData._() : super._();
+  factory _ResultData(@nullable T value) = _$_ResultData<T>;
+
+  @nullable
+  T get value;
+  @JsonKey(ignore: true)
+  _$ResultDataCopyWith<T, _ResultData<T>> get copyWith;
+}
+
+/// @nodoc
+abstract class _$ResultErrorCopyWith<T, $Res> {
+  factory _$ResultErrorCopyWith(
+          _ResultError<T> value, $Res Function(_ResultError<T>) then) =
+      __$ResultErrorCopyWithImpl<T, $Res>;
+  $Res call({Object error, StackTrace stackTrace});
+}
+
+/// @nodoc
+class __$ResultErrorCopyWithImpl<T, $Res> extends _$ResultCopyWithImpl<T, $Res>
+    implements _$ResultErrorCopyWith<T, $Res> {
+  __$ResultErrorCopyWithImpl(
+      _ResultError<T> _value, $Res Function(_ResultError<T>) _then)
+      : super(_value, (v) => _then(v as _ResultError<T>));
+
+  @override
+  _ResultError<T> get _value => super._value as _ResultError<T>;
+
+  @override
+  $Res call({
+    Object error = freezed,
+    Object stackTrace = freezed,
+  }) {
+    return _then(_ResultError<T>(
+      error == freezed ? _value.error : error,
+      stackTrace == freezed ? _value.stackTrace : stackTrace as StackTrace,
+    ));
+  }
+}
+
+/// @nodoc
+class _$_ResultError<T> extends _ResultError<T> {
+  _$_ResultError(this.error, [this.stackTrace])
+      : assert(error != null),
+        super._();
+
+  @override
+  final Object error;
+  @override
+  final StackTrace stackTrace;
+
+  @override
+  String toString() {
+    return 'Result<$T>.error(error: $error, stackTrace: $stackTrace)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other is _ResultError<T> &&
+            (identical(other.error, error) ||
+                const DeepCollectionEquality().equals(other.error, error)) &&
+            (identical(other.stackTrace, stackTrace) ||
+                const DeepCollectionEquality()
+                    .equals(other.stackTrace, stackTrace)));
+  }
+
+  @override
+  int get hashCode =>
+      runtimeType.hashCode ^
+      const DeepCollectionEquality().hash(error) ^
+      const DeepCollectionEquality().hash(stackTrace);
+
+  @JsonKey(ignore: true)
+  @override
+  _$ResultErrorCopyWith<T, _ResultError<T>> get copyWith =>
+      __$ResultErrorCopyWithImpl<T, _ResultError<T>>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object>({
+    @required TResult data(@nullable T value),
+    @required TResult error(Object error, StackTrace stackTrace),
+  }) {
+    assert(data != null);
+    assert(error != null);
+    return error(this.error, stackTrace);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object>({
+    TResult data(@nullable T value),
+    TResult error(Object error, StackTrace stackTrace),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (error != null) {
+      return error(this.error, stackTrace);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object>({
+    @required TResult data(_ResultData<T> value),
+    @required TResult error(_ResultError<T> value),
+  }) {
+    assert(data != null);
+    assert(error != null);
+    return error(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object>({
+    TResult data(_ResultData<T> value),
+    TResult error(_ResultError<T> value),
+    @required TResult orElse(),
+  }) {
+    assert(orElse != null);
+    if (error != null) {
+      return error(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _ResultError<T> extends Result<T> {
+  _ResultError._() : super._();
+  factory _ResultError(Object error, [StackTrace stackTrace]) =
+      _$_ResultError<T>;
+
+  Object get error;
+  StackTrace get stackTrace;
+  @JsonKey(ignore: true)
+  _$ResultErrorCopyWith<T, _ResultError<T>> get copyWith;
+}

--- a/packages/devtools_app/lib/src/bloc/models/bloc_node.dart
+++ b/packages/devtools_app/lib/src/bloc/models/bloc_node.dart
@@ -1,0 +1,10 @@
+class BlocNode {
+  BlocNode(this.blocId, this.blocType);
+  final String blocId, blocType;
+}
+
+class BlocState {
+  BlocState({this.fields});
+
+  final Map<String, String> fields;
+}

--- a/packages/devtools_app/lib/src/bloc/views/bloc_screen.dart
+++ b/packages/devtools_app/lib/src/bloc/views/bloc_screen.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../eval_on_dart_library.dart';
+import '../../globals.dart';
+import '../../screen.dart';
+import '../bloc/bloc_list_bloc.dart';
+import '../bloc/bloc_list_state.dart';
+import '../bloc/bloc_node_bloc.dart';
+import '../widgets/bloc_error_view.dart';
+import '../widgets/bloc_initial_view.dart';
+import '../widgets/bloc_list_view.dart';
+import '../widgets/bloc_loading_view.dart';
+
+// Entrypoint for the Bloc Screen in the DevTools UI
+class BlocScreen extends Screen {
+  const BlocScreen()
+      : super.conditional(
+            id: id,
+            requiresLibrary: 'package:flutter_bloc/',
+            title: 'Bloc',
+            icon: Icons.palette);
+
+  static const id = 'bloc';
+
+  @override
+  Widget build(BuildContext context) {
+    return const BlocScreenBody();
+  }
+}
+
+class BlocScreenBody extends StatelessWidget {
+  const BlocScreenBody({Key key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final evalOnDartLibrary = EvalOnDartLibrary(
+        ['package:bloc/src/bloc_observer.dart'], serviceManager.service);
+    return MultiBlocProvider(
+        providers: [
+          BlocProvider<BlocListBloc>(
+            create: (context) => BlocListBloc(evalOnDartLibrary, serviceManager.service),
+          ),
+          BlocProvider<BlocNodeBloc>(
+            create: (context) => BlocNodeBloc(evalOnDartLibrary, serviceManager.service),
+          )
+        ],
+        child:
+            BlocBuilder<BlocListBloc, BlocListState>(builder: (context, state) {
+          if (state.status == BlocListStatus.initial) {
+            return const BlocInitialView();
+          } else if (state.status == BlocListStatus.loading) {
+            return const BlocLoadingView();
+          } else if (state.status == BlocListStatus.success) {
+            return BlocListView(state.blocs);
+          } else {
+            return const BlocErrorView();
+          }
+        }));
+  }
+}

--- a/packages/devtools_app/lib/src/bloc/views/bloc_screen.dart
+++ b/packages/devtools_app/lib/src/bloc/views/bloc_screen.dart
@@ -20,7 +20,7 @@ class BlocScreen extends Screen {
             id: id,
             requiresLibrary: 'package:flutter_bloc/',
             title: 'Bloc',
-            icon: Icons.palette);
+            icon: Icons.palette,);
 
   static const id = 'bloc';
 

--- a/packages/devtools_app/lib/src/bloc/views/bloc_screen.dart
+++ b/packages/devtools_app/lib/src/bloc/views/bloc_screen.dart
@@ -5,6 +5,7 @@ import '../../eval_on_dart_library.dart';
 import '../../globals.dart';
 import '../../screen.dart';
 import '../bloc/bloc_list_bloc.dart';
+import '../bloc/bloc_list_event.dart';
 import '../bloc/bloc_list_state.dart';
 import '../bloc/bloc_node_bloc.dart';
 import '../widgets/bloc_error_view.dart';
@@ -39,7 +40,11 @@ class BlocScreenBody extends StatelessWidget {
     return MultiBlocProvider(
         providers: [
           BlocProvider<BlocListBloc>(
-            create: (context) => BlocListBloc(evalOnDartLibrary, serviceManager.service),
+            create: (context) {
+              final blocListBloc = BlocListBloc(evalOnDartLibrary, serviceManager.service);
+              blocListBloc.add(BlocListRequested());
+              return blocListBloc;
+            },
           ),
           BlocProvider<BlocNodeBloc>(
             create: (context) => BlocNodeBloc(evalOnDartLibrary, serviceManager.service),

--- a/packages/devtools_app/lib/src/bloc/views/bloc_screen.dart
+++ b/packages/devtools_app/lib/src/bloc/views/bloc_screen.dart
@@ -5,8 +5,6 @@ import '../../eval_on_dart_library.dart';
 import '../../globals.dart';
 import '../../screen.dart';
 import '../bloc/bloc_list_bloc.dart';
-import '../bloc/bloc_list_event.dart';
-import '../bloc/bloc_list_state.dart';
 import '../bloc/bloc_node_bloc.dart';
 import '../widgets/bloc_error_view.dart';
 import '../widgets/bloc_initial_view.dart';

--- a/packages/devtools_app/lib/src/bloc/views/bloc_screen.dart
+++ b/packages/devtools_app/lib/src/bloc/views/bloc_screen.dart
@@ -5,6 +5,8 @@ import '../../eval_on_dart_library.dart';
 import '../../globals.dart';
 import '../../screen.dart';
 import '../bloc/bloc_list_bloc.dart';
+import '../bloc/bloc_list_event.dart';
+import '../bloc/bloc_list_state.dart';
 import '../bloc/bloc_node_bloc.dart';
 import '../widgets/bloc_error_view.dart';
 import '../widgets/bloc_initial_view.dart';
@@ -15,21 +17,13 @@ import '../widgets/bloc_loading_view.dart';
 class BlocScreen extends Screen {
   const BlocScreen()
       : super.conditional(
-            id: id,
-            requiresLibrary: 'package:flutter_bloc/',
-            title: 'Bloc',
-            icon: Icons.palette,);
+          id: id,
+          requiresLibrary: 'package:flutter_bloc/',
+          title: 'Bloc',
+          icon: Icons.palette,
+        );
 
   static const id = 'bloc';
-
-  @override
-  Widget build(BuildContext context) {
-    return const BlocScreenBody();
-  }
-}
-
-class BlocScreenBody extends StatelessWidget {
-  const BlocScreenBody({Key key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -38,14 +32,13 @@ class BlocScreenBody extends StatelessWidget {
     return MultiBlocProvider(
         providers: [
           BlocProvider<BlocListBloc>(
-            create: (context) {
-              final blocListBloc = BlocListBloc(evalOnDartLibrary, serviceManager.service);
-              blocListBloc.add(BlocListRequested());
-              return blocListBloc;
-            },
+            create: (context) =>
+                BlocListBloc(evalOnDartLibrary, serviceManager.service)
+                  ..add(BlocListRequested()),
           ),
           BlocProvider<BlocNodeBloc>(
-            create: (context) => BlocNodeBloc(evalOnDartLibrary, serviceManager.service),
+            create: (context) =>
+                BlocNodeBloc(evalOnDartLibrary, serviceManager.service),
           )
         ],
         child:

--- a/packages/devtools_app/lib/src/bloc/widgets/bloc_error_view.dart
+++ b/packages/devtools_app/lib/src/bloc/widgets/bloc_error_view.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class BlocErrorView extends StatelessWidget {
+  const BlocErrorView({Key key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return const Text('Error View');
+  }
+}

--- a/packages/devtools_app/lib/src/bloc/widgets/bloc_initial_view.dart
+++ b/packages/devtools_app/lib/src/bloc/widgets/bloc_initial_view.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class BlocInitialView extends StatelessWidget {
+  const BlocInitialView({Key key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return const Text('Initial View');
+  }
+}

--- a/packages/devtools_app/lib/src/bloc/widgets/bloc_list_view.dart
+++ b/packages/devtools_app/lib/src/bloc/widgets/bloc_list_view.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../common_widgets.dart';
+import '../../inspector/inspector_tree.dart';
+import '../../split.dart';
+import '../../theme.dart';
+import '../bloc/bloc_list_event.dart';
+import '../bloc/bloc_node_bloc.dart';
+import '../instance_viewer/instance_details.dart';
+import '../instance_viewer/instance_viewer.dart';
+import '../models/bloc_node.dart';
+
+class BlocListView extends StatelessWidget {
+  const BlocListView(this._blocs, {Key key}) : super(key: key);
+
+  final List<BlocNode> _blocs;
+
+  @override
+  Widget build(BuildContext context) {
+    final splitAxis = Split.axisFor(context, 0.85);
+    final selectedBlocState = context.watch<BlocNodeBloc>().state;
+    final selectedBlocId = selectedBlocState.selectedBlocId;
+
+    return Split(axis: splitAxis, initialFractions: const [
+      0.33,
+      0.67
+    ], children: [
+      OutlineDecoration(
+          child: Column(children: [
+        const AreaPaneHeader(
+          title: Text('Blocs'),
+          needsTopBorder: false,
+        ),
+        Expanded(child: BlocList(_blocs))
+      ])),
+      OutlineDecoration(
+          child: Column(children: [
+        const AreaPaneHeader(
+          title: Text('TITLE TO BE ADDED'),
+          needsTopBorder: false,
+        ),
+        if (selectedBlocId != null)
+          Expanded(
+            child: InstanceViewer(
+              rootPath: InstancePath.fromBlocId(selectedBlocId),
+              showInternalProperties: true,
+            ),
+          )
+      ]))
+    ]);
+  }
+}
+
+class BlocList extends StatefulWidget {
+  const BlocList(this._blocs, {Key key}) : super(key: key);
+  final List<BlocNode> _blocs;
+
+  @override
+  _BlocListState createState() => _BlocListState();
+}
+
+class _BlocListState extends State<BlocList> {
+  final scrollController = ScrollController();
+
+  @override
+  void dispose() {
+    scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scrollbar(
+        controller: scrollController,
+        isAlwaysShown: true,
+        child: ListView.builder(
+            primary: false,
+            controller: scrollController,
+            itemCount: widget._blocs.length,
+            itemBuilder: (_, index) {
+              return BlocNodeView(widget._blocs[index]);
+            }));
+  }
+}
+
+const _tilePadding = EdgeInsets.only(
+  left: defaultSpacing,
+  right: densePadding,
+  top: densePadding,
+  bottom: densePadding,
+);
+
+class BlocNodeView extends StatelessWidget {
+  const BlocNodeView(this._bloc, {Key key}) : super(key: key);
+
+  final BlocNode _bloc;
+
+  @override
+  Widget build(BuildContext context) {
+    final blocState = context.read<BlocNodeBloc>().state;
+    final isSelected = blocState.selectedBlocId == _bloc.blocId;
+    final colorScheme = Theme.of(context).colorScheme;
+    final backgroundColor =
+        isSelected ? colorScheme.selectedRowBackgroundColor : null;
+
+    return GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: () =>
+            context.read<BlocNodeBloc>().add(BlocSelected(_bloc.blocId)),
+        child: Container(
+            color: backgroundColor,
+            padding: _tilePadding,
+            child: Text('${_bloc.blocType}()')));
+  }
+}

--- a/packages/devtools_app/lib/src/bloc/widgets/bloc_loading_view.dart
+++ b/packages/devtools_app/lib/src/bloc/widgets/bloc_loading_view.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class BlocLoadingView extends StatelessWidget {
+  const BlocLoadingView({Key key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return const Text('Loading View');
+  }
+}

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -57,8 +57,6 @@ dependencies:
   vm_snapshot_analysis: ^0.6.0
   web_socket_channel: ^2.1.0
   flutter_bloc: ^7.0.0
-  equatable: ^2.0.0
-
 
 dev_dependencies:
   build_runner: ^2.0.4

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -56,6 +56,9 @@ dependencies:
   vm_service: ^7.1.0
   vm_snapshot_analysis: ^0.6.0
   web_socket_channel: ^2.1.0
+  flutter_bloc: ^7.0.0
+  equatable: ^2.0.0
+
 
 dev_dependencies:
   build_runner: ^2.0.4


### PR DESCRIPTION
Current state of bloc DevTools provides support for retrieving and displaying the state of all active blocs in the attached application with realtime updates. Lacks functionality to mutate the state of blocs.